### PR TITLE
Start implementing return values for runKinematic.

### DIFF
--- a/OndselSolver/ASMTAssembly.h
+++ b/OndselSolver/ASMTAssembly.h
@@ -69,7 +69,7 @@ namespace MbD {
 		void outputFor(AnalysisType type);
 		void logString(std::string& str);
 		void logString(double value);
-		void preMbDrun(std::shared_ptr<System> mbdSys);
+		int preMbDrun(std::shared_ptr<System> mbdSys);
 		void postMbDrun();
 		void calcCharacteristicDimensions();
 		double calcCharacteristicTime();
@@ -78,12 +78,12 @@ namespace MbD {
 		std::shared_ptr<std::vector<std::shared_ptr<ASMTItemIJ>>> connectorList();
 		std::shared_ptr<std::map<std::string, std::shared_ptr<ASMTMarker>>>markerMap();
 		void deleteMbD();
-		void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+		int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
 		/* This function performs a one shot solve of the assembly.*/
-		void solve();
+		int solve();
 
-		void runKINEMATIC();
+		int runKINEMATIC();
 		void initprincipalMassMarker();
 		std::shared_ptr<ASMTSpatialContainer> spatialContainerAt(std::shared_ptr<ASMTAssembly> self, std::string& longname);
 		std::shared_ptr<ASMTMarker> markerAt(std::string& longname);

--- a/OndselSolver/ASMTConstantGravity.cpp
+++ b/OndselSolver/ASMTConstantGravity.cpp
@@ -21,12 +21,13 @@ void MbD::ASMTConstantGravity::parseASMT(std::vector<std::string>& lines)
 	lines.erase(lines.begin());
 }
 
-void MbD::ASMTConstantGravity::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTConstantGravity::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	auto mbdGravity = CREATE<ConstantGravity>::With();
 	mbdObject = mbdGravity;
 	mbdGravity->gXYZ = g->times(1.0 / mbdUnits->acceleration);
 	mbdSys->addForceTorque(mbdGravity);
+	return 0;
 }
 
 void MbD::ASMTConstantGravity::setg(FColDsptr gravity)

--- a/OndselSolver/ASMTConstantGravity.h
+++ b/OndselSolver/ASMTConstantGravity.h
@@ -20,7 +20,7 @@ namespace MbD {
         //
     public:
         void parseASMT(std::vector<std::string>& lines) override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         void setg(FColDsptr g);
 
         void setg(double a, double b, double c);

--- a/OndselSolver/ASMTConstraintSet.cpp
+++ b/OndselSolver/ASMTConstraintSet.cpp
@@ -13,7 +13,7 @@
 
 using namespace MbD;
 
-void MbD::ASMTConstraintSet::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTConstraintSet::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	//self dataSeries : OrderedCollection new.
 	//self discontinuities : OrderedCollection new.
@@ -24,6 +24,8 @@ void MbD::ASMTConstraintSet::createMbD(std::shared_ptr<System> mbdSys, std::shar
 	auto mrkJ = std::static_pointer_cast<EndFramec>(root()->markerAt(markerJ)->mbdObject);
 	mbdJt->connectsItoJ(mrkI, mrkJ);
 	mbdSys->addJoint(mbdJt);
+
+	return 0;
 }
 
 std::shared_ptr<Joint> MbD::ASMTConstraintSet::mbdClassNew()

--- a/OndselSolver/ASMTConstraintSet.h
+++ b/OndselSolver/ASMTConstraintSet.h
@@ -17,7 +17,7 @@ namespace MbD {
     {
         //
     public:
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         virtual std::shared_ptr<Joint> mbdClassNew();
         void updateFromMbD() override;
         void compareResults(AnalysisType type) override;

--- a/OndselSolver/ASMTGeneralMotion.cpp
+++ b/OndselSolver/ASMTGeneralMotion.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<Joint> MbD::ASMTGeneralMotion::mbdClassNew()
 	return CREATE<FullMotion>::With();
 }
 
-void MbD::ASMTGeneralMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int ASMTGeneralMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	ASMTMotion::createMbD(mbdSys, mbdUnits);
 	auto parser = CREATE<SymbolicParser>::With();
@@ -146,4 +146,6 @@ void MbD::ASMTGeneralMotion::createMbD(std::shared_ptr<System> mbdSys, std::shar
 	}
 	fangIJJ->rotOrder = rotOrder;
 	fullMotion->fangIJJ = fangIJJ;
+
+	return 0;
 }

--- a/OndselSolver/ASMTGeneralMotion.h
+++ b/OndselSolver/ASMTGeneralMotion.h
@@ -20,7 +20,7 @@ namespace MbD {
         void readangIJJ(std::vector<std::string>& lines);
         void readRotationOrder(std::vector<std::string>& lines);
         std::shared_ptr<Joint> mbdClassNew() override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
         std::shared_ptr<std::vector<std::string>> rIJI, angIJJ;
         std::string rotationOrder;

--- a/OndselSolver/ASMTItem.cpp
+++ b/OndselSolver/ASMTItem.cpp
@@ -131,9 +131,9 @@ void MbD::ASMTItem::deleteMbD()
 	mbdObject = nullptr;
 }
 
-void MbD::ASMTItem::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTItem::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
-	assert(false);
+	return ERR_CREATEMBD_ASMTITEM;
 }
 
 void MbD::ASMTItem::updateFromMbD()

--- a/OndselSolver/ASMTItem.h
+++ b/OndselSolver/ASMTItem.h
@@ -35,7 +35,7 @@ namespace MbD {
 		virtual std::string fullName(std::string partialName);
 		void readDoublesInto(std::string& str, std::string label, FRowDsptr& row);
 		virtual void deleteMbD();
-		virtual void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
+		virtual int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
 		virtual void updateFromMbD();
 		virtual void compareResults(AnalysisType type);
 		virtual void outputResults(AnalysisType type);

--- a/OndselSolver/ASMTMarker.cpp
+++ b/OndselSolver/ASMTMarker.cpp
@@ -50,7 +50,7 @@ FMatDsptr MbD::ASMTMarker::aApm()
 	return aApm;
 }
 
-void MbD::ASMTMarker::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTMarker::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	auto mkr = CREATE<MarkerFrame>::With(name.c_str());
 	auto prt = std::static_pointer_cast<Part>(part()->mbdObject);
@@ -59,4 +59,6 @@ void MbD::ASMTMarker::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<
 	mkr->rpmp = rpmp()->times(1.0 / mbdUnits->length);
 	mkr->aApm = aApm();
 	mbdObject = mkr->endFrames->at(0);
+
+	return 0;
 }

--- a/OndselSolver/ASMTMarker.h
+++ b/OndselSolver/ASMTMarker.h
@@ -20,7 +20,7 @@ namespace MbD {
         void parseASMT(std::vector<std::string>& lines) override;
         FColDsptr rpmp();
         FMatDsptr aApm();
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
     };
 }

--- a/OndselSolver/ASMTPointInPlaneJoint.cpp
+++ b/OndselSolver/ASMTPointInPlaneJoint.cpp
@@ -31,10 +31,12 @@ void MbD::ASMTPointInPlaneJoint::readOffset(std::vector<std::string>& lines)
 
 }
 
-void MbD::ASMTPointInPlaneJoint::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int ASMTPointInPlaneJoint::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	ASMTJoint::createMbD(mbdSys, mbdUnits);
 	auto pointInPlaneJoint = std::static_pointer_cast<PointInPlaneJoint>(mbdObject);
 	pointInPlaneJoint->offset = offset;
+
+	return 0;
 }
 

--- a/OndselSolver/ASMTPointInPlaneJoint.h
+++ b/OndselSolver/ASMTPointInPlaneJoint.h
@@ -18,7 +18,7 @@ namespace MbD {
         virtual std::shared_ptr<Joint> mbdClassNew() override;
         void parseASMT(std::vector<std::string>& lines) override;
         void readOffset(std::vector<std::string>& lines);
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
         double offset;
     };

--- a/OndselSolver/ASMTRefPoint.cpp
+++ b/OndselSolver/ASMTRefPoint.cpp
@@ -24,9 +24,11 @@ std::string MbD::ASMTRefPoint::fullName(std::string partialName)
 	return owner->fullName(partialName);
 }
 
-void MbD::ASMTRefPoint::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int ASMTRefPoint::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	for (auto& marker : *markers) {
-		marker->createMbD(mbdSys, mbdUnits);
+		int ret = marker->createMbD(mbdSys, mbdUnits);
+		if (ret != 0) { return ret; }
 	}
+	return 0;
 }

--- a/OndselSolver/ASMTRefPoint.h
+++ b/OndselSolver/ASMTRefPoint.h
@@ -19,9 +19,8 @@ namespace MbD {
     public:
         void parseASMT(std::vector<std::string>& lines) override;
         std::string fullName(std::string partialName) override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
-    
     };
 }
 

--- a/OndselSolver/ASMTRotationalMotion.cpp
+++ b/OndselSolver/ASMTRotationalMotion.cpp
@@ -47,7 +47,7 @@ void MbD::ASMTRotationalMotion::initMarkers()
 	markerJ = jt->markerJ;
 }
 
-void MbD::ASMTRotationalMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTRotationalMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	ASMTMotion::createMbD(mbdSys, mbdUnits);
 	auto parser = CREATE<SymbolicParser>::With();
@@ -60,6 +60,8 @@ void MbD::ASMTRotationalMotion::createMbD(std::shared_ptr<System> mbdSys, std::s
 	geoPhi = Symbolic::times(geoPhi, std::make_shared<Constant>(1.0 / mbdUnits->angle));
 	geoPhi->createMbD(mbdSys, mbdUnits);
 	std::static_pointer_cast<ZRotation>(mbdObject)->phiBlk = geoPhi->simplified(geoPhi);
+
+	return 0;
 }
 
 std::shared_ptr<Joint> MbD::ASMTRotationalMotion::mbdClassNew()

--- a/OndselSolver/ASMTRotationalMotion.h
+++ b/OndselSolver/ASMTRotationalMotion.h
@@ -20,7 +20,7 @@ namespace MbD {
         void readMotionJoint(std::vector<std::string>& lines);
         void readRotationZ(std::vector<std::string>& lines);
         void initMarkers() override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         std::shared_ptr<Joint> mbdClassNew() override;
         void setMotionJoint(std::string motionJoint);
         void setRotationZ(std::string rotZ);

--- a/OndselSolver/ASMTSpatialContainer.cpp
+++ b/OndselSolver/ASMTSpatialContainer.cpp
@@ -240,7 +240,7 @@ void MbD::ASMTSpatialContainer::readAlphaZs(std::vector<std::string>& lines)
 	lines.erase(lines.begin());
 }
 
-void MbD::ASMTSpatialContainer::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTSpatialContainer::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	auto mbdPart = CREATE<Part>::With();
 	mbdObject = mbdPart;
@@ -263,6 +263,7 @@ void MbD::ASMTSpatialContainer::createMbD(std::shared_ptr<System> mbdSys, std::s
 	for (auto& refSurface : *refSurfaces) {
 		refSurface->createMbD(mbdSys, mbdUnits);
 	}
+	return 0;
 }
 
 FColDsptr MbD::ASMTSpatialContainer::rOcmO()

--- a/OndselSolver/ASMTSpatialContainer.h
+++ b/OndselSolver/ASMTSpatialContainer.h
@@ -59,7 +59,7 @@ namespace MbD {
         void readAlphaXs(std::vector<std::string>& lines);
         void readAlphaYs(std::vector<std::string>& lines);
         void readAlphaZs(std::vector<std::string>& lines);
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         FColDsptr rOcmO();
         std::shared_ptr<EulerParameters<double>> qEp();
         virtual FColDsptr vOcmO();

--- a/OndselSolver/ASMTTime.cpp
+++ b/OndselSolver/ASMTTime.cpp
@@ -21,11 +21,15 @@ void MbD::ASMTTime::deleteMbD()
 	expression = nullptr;
 }
 
-void MbD::ASMTTime::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTTime::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	auto mbdTime = mbdSys->time;
-	if (xx == mbdTime) return;
+	if (xx == mbdTime) {
+		return ERR_CREATEMBD_TIME_XXERR;
+	}
 	auto timeScale = std::make_shared<Constant>(mbdUnits->time);
 	auto geoTime = std::make_shared<Product>(timeScale, mbdTime);
 	this->xexpression(mbdTime, geoTime->simplified(geoTime));
+
+	return 0;
 }

--- a/OndselSolver/ASMTTime.h
+++ b/OndselSolver/ASMTTime.h
@@ -18,7 +18,7 @@ namespace MbD {
         //
     public:
         void deleteMbD();
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
 
     };
 }

--- a/OndselSolver/ASMTTranslationalMotion.cpp
+++ b/OndselSolver/ASMTTranslationalMotion.cpp
@@ -46,7 +46,7 @@ void MbD::ASMTTranslationalMotion::initMarkers()
 	markerJ = jt->markerJ;
 }
 
-void MbD::ASMTTranslationalMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::ASMTTranslationalMotion::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	ASMTMotion::createMbD(mbdSys, mbdUnits);
 	auto parser = CREATE<SymbolicParser>::With();
@@ -59,6 +59,8 @@ void MbD::ASMTTranslationalMotion::createMbD(std::shared_ptr<System> mbdSys, std
 	zIJ = Symbolic::times(zIJ, std::make_shared<Constant>(1.0 / mbdUnits->length));
 	zIJ->createMbD(mbdSys, mbdUnits);
 	std::static_pointer_cast<ZTranslation>(mbdObject)->zBlk = zIJ->simplified(zIJ);
+
+	return 0;
 }
 
 std::shared_ptr<Joint> MbD::ASMTTranslationalMotion::mbdClassNew()

--- a/OndselSolver/ASMTTranslationalMotion.h
+++ b/OndselSolver/ASMTTranslationalMotion.h
@@ -17,7 +17,7 @@ namespace MbD {
     public:
         void parseASMT(std::vector<std::string>& lines) override;
         void initMarkers() override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         std::shared_ptr<Joint> mbdClassNew() override;
         void readMotionJoint(std::vector<std::string>& lines);
         void readTranslationZ(std::vector<std::string>& lines);

--- a/OndselSolver/CADSystem.cpp
+++ b/OndselSolver/CADSystem.cpp
@@ -834,12 +834,14 @@ void CADSystem::runPiston()
 	TheSystem->runKINEMATIC(TheSystem);
 }
 
-void MbD::CADSystem::preMbDrun(std::shared_ptr<System> mbdSys)
+int MbD::CADSystem::preMbDrun(std::shared_ptr<System> mbdSys)
 {
+	return 0;
 }
 
-void CADSystem::postMbDrun()
+int CADSystem::postMbDrun()
 {
+	return 0;
 }
 
 void MbD::CADSystem::updateFromMbD()

--- a/OndselSolver/CADSystem.h
+++ b/OndselSolver/CADSystem.h
@@ -31,8 +31,8 @@ namespace MbD {
 		void runOndselDoublePendulum();
 		void runOndselPiston();
 		void runPiston();
-		void preMbDrun(std::shared_ptr<System> mbdSys);
-		void postMbDrun();
+		int preMbDrun(std::shared_ptr<System> mbdSys);
+		int postMbDrun();
 		void updateFromMbD();
 
 		std::shared_ptr<System> mbdSystem = std::make_shared<System>();

--- a/OndselSolver/Constant.cpp
+++ b/OndselSolver/Constant.cpp
@@ -50,9 +50,9 @@ bool MbD::Constant::isOne()
 	return value == 1.0;
 }
 
-void MbD::Constant::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int Constant::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
-	return;
+	return 0;
 }
 
 double MbD::Constant::getValue()

--- a/OndselSolver/Constant.h
+++ b/OndselSolver/Constant.h
@@ -22,7 +22,7 @@ namespace MbD {
         Symsptr clonesptr() override;
         bool isZero() override;
         bool isOne() override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         double getValue() override;
 
         std::ostream& printOn(std::ostream& s) const override;

--- a/OndselSolver/ExternalSystem.cpp
+++ b/OndselSolver/ExternalSystem.cpp
@@ -13,17 +13,15 @@
 
 using namespace MbD;
 
-void MbD::ExternalSystem::preMbDrun(std::shared_ptr<System> mbdSys)
+int MbD::ExternalSystem::preMbDrun(std::shared_ptr<System> mbdSys)
 {
 	if (cadSystem) {
-		cadSystem->preMbDrun(mbdSys);
+		return cadSystem->preMbDrun(mbdSys);
 	}
 	else if (asmtAssembly) {
-		asmtAssembly->preMbDrun(mbdSys);
+		return asmtAssembly->preMbDrun(mbdSys);
 	}
-	else {
-		assert(false);
-	}
+	return ERR_PREMBDRUN;
 }
 
 void MbD::ExternalSystem::outputFor(AnalysisType type)

--- a/OndselSolver/ExternalSystem.h
+++ b/OndselSolver/ExternalSystem.h
@@ -24,7 +24,7 @@ namespace MbD {
 	{
 		//
 	public:
-		void preMbDrun(std::shared_ptr<System> mbdSys);
+		int preMbDrun(std::shared_ptr<System> mbdSys);
 		void outputFor(AnalysisType type);
 		void logString(std::string& str);
 		void logString(double value);

--- a/OndselSolver/FunctionWithManyArgs.cpp
+++ b/OndselSolver/FunctionWithManyArgs.cpp
@@ -5,7 +5,7 @@
  *                                                                         *
  *   See LICENSE file for details about copyright.                         *
  ***************************************************************************/
- 
+
 #include "FunctionWithManyArgs.h"
 #include "Symbolic.h"
 
@@ -42,9 +42,14 @@ std::shared_ptr<std::vector<Symsptr>> FunctionWithManyArgs::getTerms()
 	return terms;
 }
 
-void MbD::FunctionWithManyArgs::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int FunctionWithManyArgs::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
-	for (auto& term : *terms) term->createMbD(mbdSys, mbdUnits);
+	for (auto& term : *terms) {
+		int ret = term->createMbD(mbdSys, mbdUnits);
+		if (ret != 0) {	return ret; }
+	}
+
+	return 0;
 }
 
 void MbD::FunctionWithManyArgs::arguments(Symsptr args)

--- a/OndselSolver/FunctionWithManyArgs.h
+++ b/OndselSolver/FunctionWithManyArgs.h
@@ -25,7 +25,7 @@ namespace MbD {
         FunctionWithManyArgs(Symsptr term, Symsptr term1, Symsptr term2);
         FunctionWithManyArgs(std::shared_ptr<std::vector<Symsptr>> _terms);
         std::shared_ptr<std::vector<Symsptr>> getTerms() override;
-        void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
         void arguments(Symsptr args) override;
 
         std::shared_ptr<std::vector<Symsptr>> terms;

--- a/OndselSolver/FunctionX.cpp
+++ b/OndselSolver/FunctionX.cpp
@@ -38,7 +38,8 @@ Symsptr MbD::FunctionX::differentiateWRTx()
 	return Symsptr();
 }
 
-void MbD::FunctionX::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int FunctionX::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
 	xx->createMbD(mbdSys, mbdUnits);
+	return 0;
 }

--- a/OndselSolver/FunctionX.h
+++ b/OndselSolver/FunctionX.h
@@ -23,7 +23,7 @@ namespace MbD {
 		void arguments(Symsptr args) override;
 		Symsptr differentiateWRT(Symsptr var) override;
 		virtual Symsptr differentiateWRTx();
-		void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+		int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
 
 		Symsptr xx;
 

--- a/OndselSolver/OndselSolver.cpp
+++ b/OndselSolver/OndselSolver.cpp
@@ -25,24 +25,24 @@ void runSpMat();
 int main()
 {
 	//MBDynSystem::runFile("crank_slider.mbd");		//To be completed
-	//ASMTAssembly::runSinglePendulumSuperSimplified();	//Mass is missing
-	ASMTAssembly::runSinglePendulumSimplified();
-	ASMTAssembly::runSinglePendulum();	
-	ASMTAssembly::runFile("piston.asmt");
-	ASMTAssembly::runFile("00backhoe.asmt");
+	ASMTAssembly::runSinglePendulumSuperSimplified();	//Mass is missing
+	//ASMTAssembly::runSinglePendulumSimplified();
+	//ASMTAssembly::runSinglePendulum();	
+	//ASMTAssembly::runFile("piston.asmt");
+	//ASMTAssembly::runFile("00backhoe.asmt");
 	//ASMTAssembly::runFile("circular.asmt");	//Needs checking
 	//ASMTAssembly::runFile("cirpendu.asmt");	//Under constrained. Testing ICKine.
 	//ASMTAssembly::runFile("engine1.asmt");	//Needs checking
-	ASMTAssembly::runFile("fourbar.asmt");
+	//ASMTAssembly::runFile("fourbar.asmt");
 	//ASMTAssembly::runFile("fourbot.asmt");	//Very large but works
-	ASMTAssembly::runFile("wobpump.asmt");
+	//ASMTAssembly::runFile("wobpump.asmt");
 
-	auto cadSystem = std::make_shared<CADSystem>();
-	cadSystem->runOndselSinglePendulum();
-	cadSystem->runOndselDoublePendulum();
+	//auto cadSystem = std::make_shared<CADSystem>();
+	//cadSystem->runOndselSinglePendulum();
+	//cadSystem->runOndselDoublePendulum();
 	//cadSystem->runOndselPiston();		//For debugging
-	cadSystem->runPiston();
-	runSpMat();
+	//cadSystem->runPiston();
+	//runSpMat();
 }
 
 void runSpMat() {

--- a/OndselSolver/Symbolic.cpp
+++ b/OndselSolver/Symbolic.cpp
@@ -173,10 +173,9 @@ double Symbolic::getValue()
 	return 0.0;
 }
 
-void MbD::Symbolic::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
+int MbD::Symbolic::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
-	assert(false);
-	return;
+	return ERR_CREATEMBD_SYMBOLIC;
 }
 
 Symsptr MbD::Symbolic::clonesptr()

--- a/OndselSolver/Symbolic.h
+++ b/OndselSolver/Symbolic.h
@@ -46,7 +46,7 @@ namespace MbD {
 		virtual std::shared_ptr<std::vector<Symsptr>> getTerms();
 		virtual void addTerm(Symsptr trm);
 		virtual double getValue();
-		virtual void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
+		virtual int createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits);
 		virtual Symsptr clonesptr();
 		std::shared_ptr<Constant> sptrConstant(double value);
 

--- a/OndselSolver/System.cpp
+++ b/OndselSolver/System.cpp
@@ -65,9 +65,13 @@ void MbD::System::addForceTorque(std::shared_ptr<ForceTorqueItem> forTor)
 	forcesTorques->push_back(forTor);
 }
 
-void System::runKINEMATIC(std::shared_ptr<System> self)
+int System::runKINEMATIC(std::shared_ptr<System> self)
 {
-	externalSystem->preMbDrun(self);
+	int ret = externalSystem->preMbDrun(self);
+	if (ret != 0) {
+		return ret;
+	}
+
 	while (true)
 	{
 		initializeLocally();
@@ -80,6 +84,7 @@ void System::runKINEMATIC(std::shared_ptr<System> self)
 	externalSystem->outputFor(INITIALCONDITION);
 	systemSolver->runBasicKinematic();
 	externalSystem->postMbDrun();
+	return 0;
 }
 
 void System::initializeLocally()

--- a/OndselSolver/System.h
+++ b/OndselSolver/System.h
@@ -22,6 +22,21 @@
 
 #include "Item.h"
 
+#define ERR_PREMBDRUN 1000
+#define ERR_PREMBDRUN_SIMPARAMETERMISSING 1001
+#define ERR_CREATEMBD_DIVBY0_TIME 1100
+#define ERR_CREATEMBD_DIVBY0_LENGTH 1101
+#define ERR_CREATEMBD_DIVBY0_MASS 1102
+#define ERR_CREATEMBD_DIVBY0_VELOCITY 1103
+#define ERR_CREATEMBD_DIVBY0_OMEGA 1104
+#define ERR_CREATEMBD_DIVBY0_AJ 1105
+#define ERR_CREATEMBD_DIVBY0_ACCELERATION 1106
+#define ERR_CREATEMBD_DIVBY0_ANGLE 1107
+
+#define ERR_CREATEMBD_ASMTITEM 1205
+#define ERR_CREATEMBD_SYMBOLIC 1205
+#define ERR_CREATEMBD_TIME_XXERR 1206
+
 namespace MbD {
 	class Part;
 	class Joint;
@@ -43,7 +58,7 @@ namespace MbD {
 		void initializeLocally() override;
 		void initializeGlobally() override;
 		void clear();
-		void runKINEMATIC(std::shared_ptr<System> self);
+		int runKINEMATIC(std::shared_ptr<System> self);
 		std::shared_ptr<std::vector<std::string>> discontinuitiesAtIC();
 		void jointsMotionsDo(const std::function <void(std::shared_ptr<Joint>)>& f);
 		void partsJointsMotionsDo(const std::function <void(std::shared_ptr<Item>)>& f);


### PR DESCRIPTION
So the general idea is that runKinematic() should return an int. 0 if it worked. Else an error code.

During the simulation, we need to catch potential crash and prevent them.
One example : 
`	mbdSysSolver->tstart = simulationParameters->tstart / mbdUnits->time;`

If mbdUnits->time = 0.0 then it will crash. So there should be a safe-guard before, so that if time is 0, then the run is aborted : 

`	if (mbdUnits->time == 0.0) { return ERR_CREATEMBD_DIVBY0_TIME; }`

Same is true when trying to access pointers. Perhaps the pointer does not exist. So before trying to access it, test if it exist and abort if it doesn't.

Notes : 
- error definitions were implemented in system.h
- return value has been implemented in preMbDrun and in most createMbD functions. Though in many functions I did not implement error codes as I wasn't sure what to test. So they just return 0 at the end.