### PR TITLE
include GNUInstallDirs in /CmakeLists.txt - fixes wrong install path for pkgconfig con windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(OndselSolver VERSION 1.0.1 DESCRIPTION "Assembly Constraints and Multibo
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+include(GNUInstallDirs)
+
 set(ONDSEL_EXPORT
         OndselSolver/Abs.cpp
         OndselSolver/AbsConstraint.cpp


### PR DESCRIPTION
without this ${CMAKE_INSTALL_DATAROOTDIR} is empty and the pkgconfig direcotry gets installed to the root of the C:\ drive