### PR TITLE
Werner compil warning

### DIFF
--- a/OndselSolver/ASMTAssembly.cpp
+++ b/OndselSolver/ASMTAssembly.cpp
@@ -1215,13 +1215,13 @@ void MbD::ASMTAssembly::storeOnTimeSeries(std::ofstream& os)
 	if (times->empty()) return;
 	os << "TimeSeries" << std::endl;
 	os << "Number\tInput\t";
-	for (int i = 1; i < times->size(); i++)
+	for (size_t i = 1; i < times->size(); i++)
 	{
 		os << i << '\t';
 	}
 	os << std::endl;
 	os << "Time\tInput\t";
-	for (int i = 1; i < times->size(); i++)
+	for (size_t i = 1; i < times->size(); i++)
 	{
 		os << times->at(i) << '\t';
 	}

--- a/OndselSolver/ASMTItem.cpp
+++ b/OndselSolver/ASMTItem.cpp
@@ -220,7 +220,7 @@ void MbD::ASMTItem::storeOnLevelBool(std::ofstream& os, int level, bool value)
 void MbD::ASMTItem::storeOnLevelArray(std::ofstream& os, int level, std::vector<double> array)
 {
 	storeOnLevelTabs(os, level);
-	for (int i = 0; i < array.size(); i++)
+	for (size_t i = 0; i < array.size(); i++)
 	{
 		os << array[i] << '\t';
 	}

--- a/OndselSolver/ASMTItem.h
+++ b/OndselSolver/ASMTItem.h
@@ -20,6 +20,7 @@ namespace MbD {
 	{
 		//
 	public:
+		virtual ~ASMTItem() {}
 		virtual ASMTAssembly* root();
 		virtual ASMTSpatialContainer* partOrAssembly();
 		virtual ASMTPart* part();

--- a/OndselSolver/ASMTItem.h
+++ b/OndselSolver/ASMTItem.h
@@ -64,7 +64,7 @@ namespace MbD {
 	//inline void ASMTItem::storeOnLevelArray(std::ofstream& os, int level, std::vector<T> array)
 	//{
 	//	storeOnLevelTabs(os, level);
-	//	for (int i = 0; i < array.size(); i++)
+	//	for (size_t i = 0; i < array.size(); i++)
 	//	{
 	//		os << array[i] << '\t';
 	//	}

--- a/OndselSolver/ASMTItemIJ.cpp
+++ b/OndselSolver/ASMTItemIJ.cpp
@@ -108,37 +108,37 @@ void MbD::ASMTItemIJ::storeOnLevel(std::ofstream& os, int level)
 void MbD::ASMTItemIJ::storeOnTimeSeries(std::ofstream& os)
 {
 	os << "FXonI\t";
-	for (int i = 0; i < fxs->size(); i++)
+	for (size_t i = 0; i < fxs->size(); i++)
 	{
 		os << fxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "FYonI\t";
-	for (int i = 0; i < fys->size(); i++)
+	for (size_t i = 0; i < fys->size(); i++)
 	{
 		os << fys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "FZonI\t";
-	for (int i = 0; i < fzs->size(); i++)
+	for (size_t i = 0; i < fzs->size(); i++)
 	{
 		os << fzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TXonI\t";
-	for (int i = 0; i < txs->size(); i++)
+	for (size_t i = 0; i < txs->size(); i++)
 	{
 		os << txs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TYonI\t";
-	for (int i = 0; i < tys->size(); i++)
+	for (size_t i = 0; i < tys->size(); i++)
 	{
 		os << tys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TZonI\t";
-	for (int i = 0; i < tzs->size(); i++)
+	for (size_t i = 0; i < tzs->size(); i++)
 	{
 		os << tzs->at(i) << '\t';
 	}

--- a/OndselSolver/ASMTSpatialContainer.cpp
+++ b/OndselSolver/ASMTSpatialContainer.cpp
@@ -601,109 +601,109 @@ void MbD::ASMTSpatialContainer::storeOnLevelRefSurfaces(std::ofstream& os, int l
 void MbD::ASMTSpatialContainer::storeOnTimeSeries(std::ofstream& os)
 {
 	os << "X\t";
-	for (int i = 0; i < xs->size(); i++)
+	for (size_t i = 0; i < xs->size(); i++)
 	{
 		os << xs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Y\t";
-	for (int i = 0; i < ys->size(); i++)
+	for (size_t i = 0; i < ys->size(); i++)
 	{
 		os << ys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Z\t";
-	for (int i = 0; i < zs->size(); i++)
+	for (size_t i = 0; i < zs->size(); i++)
 	{
 		os << zs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryantx\t";
-	for (int i = 0; i < bryxs->size(); i++)
+	for (size_t i = 0; i < bryxs->size(); i++)
 	{
 		os << bryxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryanty\t";
-	for (int i = 0; i < bryys->size(); i++)
+	for (size_t i = 0; i < bryys->size(); i++)
 	{
 		os << bryys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryantz\t";
-	for (int i = 0; i < bryzs->size(); i++)
+	for (size_t i = 0; i < bryzs->size(); i++)
 	{
 		os << bryzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VX\t";
-	for (int i = 0; i < vxs->size(); i++)
+	for (size_t i = 0; i < vxs->size(); i++)
 	{
 		os << vxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VY\t";
-	for (int i = 0; i < vys->size(); i++)
+	for (size_t i = 0; i < vys->size(); i++)
 	{
 		os << vys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VZ\t";
-	for (int i = 0; i < vzs->size(); i++)
+	for (size_t i = 0; i < vzs->size(); i++)
 	{
 		os << vzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaX\t";
-	for (int i = 0; i < omexs->size(); i++)
+	for (size_t i = 0; i < omexs->size(); i++)
 	{
 		os << omexs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaY\t";
-	for (int i = 0; i < omeys->size(); i++)
+	for (size_t i = 0; i < omeys->size(); i++)
 	{
 		os << omeys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaZ\t";
-	for (int i = 0; i < omezs->size(); i++)
+	for (size_t i = 0; i < omezs->size(); i++)
 	{
 		os << omezs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AX\t";
-	for (int i = 0; i < axs->size(); i++)
+	for (size_t i = 0; i < axs->size(); i++)
 	{
 		os << axs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AY\t";
-	for (int i = 0; i < ays->size(); i++)
+	for (size_t i = 0; i < ays->size(); i++)
 	{
 		os << ays->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AZ\t";
-	for (int i = 0; i < azs->size(); i++)
+	for (size_t i = 0; i < azs->size(); i++)
 	{
 		os << azs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaX\t";
-	for (int i = 0; i < alpxs->size(); i++)
+	for (size_t i = 0; i < alpxs->size(); i++)
 	{
 		os << alpxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaY\t";
-	for (int i = 0; i < alpys->size(); i++)
+	for (size_t i = 0; i < alpys->size(); i++)
 	{
 		os << alpys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaZ\t";
-	for (int i = 0; i < alpzs->size(); i++)
+	for (size_t i = 0; i < alpzs->size(); i++)
 	{
 		os << alpzs->at(i) << '\t';
 	}

--- a/OndselSolver/Array.h
+++ b/OndselSolver/Array.h
@@ -65,14 +65,14 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::copyFrom(std::shared_ptr<Array<T>> x)
 	{
-		for (int i = 0; i < x->size(); i++) {
+		for (size_t i = 0; i < x->size(); i++) {
 			this->at(i) = x->at(i);
 		}
 	}
 	template<typename T>
 	inline void Array<T>::zeroSelf()
 	{
-		for (int i = 0; i < this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i) = (T)0;
 		}
 	}
@@ -97,7 +97,7 @@ namespace MbD {
 	//inline double Array<double>::maxMagnitude()
 	//{
 	//	double max = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < this->size(); i++)
 	//	{
 	//		auto element = this->at(i);
 	//		if (element < 0.0) element = -element;
@@ -109,7 +109,7 @@ namespace MbD {
 	inline double Array<T>::maxMagnitudeOfVector()
 	{
 		double answer = 0.0;
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double mag = std::abs(this->at(i));
 			if (answer < mag) answer = mag;
@@ -119,7 +119,7 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::equalArrayAt(std::shared_ptr<Array<T>> array, int i)
 	{
-		for (int ii = 0; ii < this->size(); ii++)
+		for (size_t ii = 0; ii < this->size(); ii++)
 		{
 			this->at(ii) = array->at((size_t)i + ii);
 		}
@@ -141,7 +141,7 @@ namespace MbD {
 	//template<>
 	//inline void Array<double>::conditionSelfWithTol(double tol)
 	//{
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < this->size(); i++)
 	//	{
 	//		double element = this->at(i);
 	//		if (element < 0.0) element = -element;
@@ -157,7 +157,7 @@ namespace MbD {
 	//inline double Array<double>::length()
 	//{
 	//	double ssq = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < this->size(); i++)
 	//	{
 	//		double elem = this->at(i);
 	//		ssq += elem * elem;
@@ -167,7 +167,7 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::magnifySelf(T factor)
 	{
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			this->atitimes(i, factor);
 		}

--- a/OndselSolver/Array.h
+++ b/OndselSolver/Array.h
@@ -31,6 +31,7 @@ namespace MbD {
 		Array(int count, const T& value) : std::vector<T>(count, value) {}
 		Array(typename std::vector<T>::iterator begin, typename std::vector<T>::iterator end) : std::vector<T>(begin, end) {}
 		Array(std::initializer_list<T> list) : std::vector<T>{ list } {}
+		virtual ~Array() {}
 		virtual void initialize();
 		void copyFrom(std::shared_ptr<Array<T>> x);
 		virtual void zeroSelf();

--- a/OndselSolver/DiagonalMatrix.cpp
+++ b/OndselSolver/DiagonalMatrix.cpp
@@ -23,7 +23,7 @@ namespace MbD {
     }
     void DiagonalMatrix::atiputDiagonalMatrix(int i, std::shared_ptr<DiagonalMatrix> diagMat)
     {
-        for (int ii = 0; ii < diagMat->size(); ii++)
+        for (size_t ii = 0; ii < diagMat->size(); ii++)
         {
             this->at(i + ii) = diagMat->at(ii);
         }
@@ -53,7 +53,7 @@ namespace MbD {
     double DiagonalMatrix::sumOfSquares()
     {
         double sum = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             double element = this->at(i);
             sum += element * element;
@@ -67,14 +67,14 @@ namespace MbD {
     }
     void DiagonalMatrix::zeroSelf()
     {
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i) = 0.0;
         }
     }
     double DiagonalMatrix::maxMagnitude()
     {
         double max = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             double element = this->at(i);
             if (element < 0.0) element = -element;
@@ -86,7 +86,7 @@ namespace MbD {
     {
         s << "DiagMat[";
         s << this->at(0);
-        for (int i = 1; i < this->size(); i++)
+        for (size_t i = 1; i < this->size(); i++)
         {
             s << ", " << this->at(i);
         }

--- a/OndselSolver/DifferenceOperator.cpp
+++ b/OndselSolver/DifferenceOperator.cpp
@@ -18,7 +18,7 @@ using namespace MbD;
 
 FRowDsptr DifferenceOperator::OneOverFactorials = []() {
 	auto oneOverFactorials = std::make_shared<FullRow<double>>(10);
-	for (int i = 0; i < oneOverFactorials->size(); i++)
+	for (size_t i = 0; i < oneOverFactorials->size(); i++)
 	{
 		oneOverFactorials->at(i) = 1.0 / std::tgamma(i + 1);
 	}

--- a/OndselSolver/DifferenceOperator.h
+++ b/OndselSolver/DifferenceOperator.h
@@ -17,6 +17,7 @@ namespace MbD {
 	{
 		//iStep order taylorMatrix operatorMatrix time timeNodes 
 	public:
+		virtual ~DifferenceOperator() {}
 		void calcOperatorMatrix();
 		virtual void initialize();
 		virtual void initializeLocally();

--- a/OndselSolver/FullColumn.cpp
+++ b/OndselSolver/FullColumn.cpp
@@ -58,7 +58,7 @@ namespace MbD {
     template<typename T>
     void FullColumn<T>::atiputFullColumn(int i, FColsptr<T> fullCol)
     {
-        for (int ii = 0; ii < fullCol->size(); ii++)
+        for (size_t ii = 0; ii < fullCol->size(); ii++)
         {
             this->at(i + ii) = fullCol->at(ii);
         }
@@ -66,7 +66,7 @@ namespace MbD {
     template<typename T>
     void FullColumn<T>::atiplusFullColumn(int i, FColsptr<T> fullCol)
     {
-        for (int ii = 0; ii < fullCol->size(); ii++)
+        for (size_t ii = 0; ii < fullCol->size(); ii++)
         {
             this->at(i + ii) += fullCol->at(ii);
         }
@@ -75,7 +75,7 @@ namespace MbD {
     void FullColumn<T>::equalSelfPlusFullColumnAt(FColsptr<T> fullCol, int ii)
     {
         //self is subcolumn of fullCol
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             this->at(i) += fullCol->at(ii + i);
         }
@@ -83,7 +83,7 @@ namespace MbD {
     template<typename T>
     void FullColumn<T>::atiminusFullColumn(int i1, FColsptr<T> fullCol)
     {
-        for (int ii = 0; ii < fullCol->size(); ii++)
+        for (size_t ii = 0; ii < fullCol->size(); ii++)
         {
             int i = i1 + ii;
             this->at(i) -= fullCol->at(ii);
@@ -93,7 +93,7 @@ namespace MbD {
     void FullColumn<T>::equalFullColumnAt(FColsptr<T> fullCol, int i)
     {
         this->equalArrayAt(fullCol, i);
-        //for (int ii = 0; ii < this->size(); ii++)
+        //for (size_t ii = 0; ii < this->size(); ii++)
         //{
         //	this->at(ii) = fullCol->at(i + ii);
         //}
@@ -117,7 +117,7 @@ namespace MbD {
     template<typename T>
     void FullColumn<T>::atiplusFullColumntimes(int i1, FColsptr<T> fullCol, T factor)
     {
-        for (int ii = 0; ii < fullCol->size(); ii++)
+        for (size_t ii = 0; ii < fullCol->size(); ii++)
         {
             int i = i1 + ii;
             this->at(i) += fullCol->at(ii) * factor;

--- a/OndselSolver/FullColumn.h
+++ b/OndselSolver/FullColumn.h
@@ -59,7 +59,7 @@ namespace MbD {
     {
         s << "FullCol{";
         s << this->at(0);
-        for (int i = 1; i < int(this->size()); i++)
+        for (size_t i = 1; i < this->size(); i++)
         {
             s << ", " << this->at(i);
         }

--- a/OndselSolver/FullMatrix.cpp
+++ b/OndselSolver/FullMatrix.cpp
@@ -257,32 +257,32 @@ namespace MbD {
     }
     void FullMatrixDouble::zeroSelf()
     {
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i)->zeroSelf();
         }
     }
     void FullMatrixFullMatrixDouble::zeroSelf()
     {
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i)->zeroSelf();
         }
     }
     void FullMatrixFullColumnDouble::zeroSelf()
     {
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i)->zeroSelf();
         }
     }
     void FullMatrixDouble::identity() {
         this->zeroSelf();
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i)->at(i) = 1.0;
         }
     }
     void FullMatrixFullMatrixDouble::identity() {
         assert(false);
 //    this->zeroSelf();
-//    for (int i = 0; i < this->size(); i++) {
+//    for (size_t i = 0; i < this->size(); i++) {
 //        this->at(i)->at(i) = 1.0;
 //    }
     }
@@ -410,7 +410,7 @@ namespace MbD {
     }
     void FullMatrixDouble::atijputFullColumn(int i1, int j1, FColsptr<double> fullCol)
     {
-        for (int ii = 0; ii < fullCol->size(); ii++)
+        for (size_t ii = 0; ii < fullCol->size(); ii++)
         {
             this->at(i1 + ii)->at(j1) = fullCol->at(ii);
         }
@@ -432,7 +432,7 @@ namespace MbD {
     double FullMatrixDouble::sumOfSquares()
     {
         double sum = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             sum += this->at(i)->sumOfSquares();
         }
@@ -441,7 +441,7 @@ namespace MbD {
     double FullMatrixFullMatrixDouble::sumOfSquares()
     {
         double sum = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             sum += this->at(i)->sumOfSquares();
         }
@@ -450,7 +450,7 @@ namespace MbD {
     double FullMatrixFullColumnDouble::sumOfSquares()
     {
         double sum = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             sum += this->at(i)->sumOfSquares();
         }
@@ -482,14 +482,14 @@ namespace MbD {
     }
     void FullMatrixDouble::magnifySelf(double factor)
     {
-        for (int i = 0; i < this->size(); i++) {
+        for (size_t i = 0; i < this->size(); i++) {
             this->at(i)->magnifySelf(factor);
         }
     }
     std::ostream& FullMatrixDouble::printOn(std::ostream& s) const
     {
         s << "FullMat[" << std::endl;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             s << *(this->at(i)) << std::endl;
         }
@@ -558,7 +558,7 @@ namespace MbD {
     double FullMatrixDouble::trace()
     {
         double trace = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             trace += this->at(i)->at(i);
         }
@@ -567,7 +567,7 @@ namespace MbD {
     double FullMatrixDouble::maxMagnitude()
     {
         double max = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             double element = this->at(i)->maxMagnitude();
             if (max < element) max = element;
@@ -577,7 +577,7 @@ namespace MbD {
     double FullMatrixFullMatrixDouble::maxMagnitude()
     {
         double max = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             double element = this->at(i)->maxMagnitude();
             if (max < element) max = element;
@@ -587,7 +587,7 @@ namespace MbD {
     double FullMatrixFullColumnDouble::maxMagnitude()
     {
         double max = 0.0;
-        for (int i = 0; i < this->size(); i++)
+        for (size_t i = 0; i < this->size(); i++)
         {
             double element = this->at(i)->maxMagnitude();
             if (max < element) max = element;

--- a/OndselSolver/FullRow.cpp
+++ b/OndselSolver/FullRow.cpp
@@ -66,7 +66,7 @@ namespace MbD {
     FRowsptr<double> FullRow<double>::timesFullMatrix(std::shared_ptr<FullMatrixDouble> fullMat)
     {
         FRowsptr<double> answer = fullMat->at(0)->times(this->at(0));
-        for (int j = 1; j < (int) this->size(); j++)
+        for (size_t j = 1; j < this->size(); j++)
         {
             answer->equalSelfPlusFullRowTimes(fullMat->at(j), this->at(j));
         }

--- a/OndselSolver/FullRow.h
+++ b/OndselSolver/FullRow.h
@@ -99,7 +99,7 @@ namespace MbD {
 	inline T FullRow<T>::timesFullColumn(FullColumn<T>* fullCol)
 	{
 		auto answer = this->at(0) * fullCol->at(0);
-		for (int i = 1; i < this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			answer += this->at(i) * fullCol->at(i);
 		}
@@ -134,7 +134,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullRow<T>::atiplusFullRow(int j1, FRowsptr<T> fullRow)
 	{
-		for (int jj = 0; jj < fullRow->size(); jj++)
+		for (size_t jj = 0; jj < fullRow->size(); jj++)
 		{
 			auto j = j1 + jj;
 			this->at(j) += fullRow->at(jj);
@@ -176,7 +176,7 @@ namespace MbD {
 	{
 		s << "FullRow{";
 		s << this->at(0);
-		for (int i = 1; i < this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}

--- a/OndselSolver/FullVector.h
+++ b/OndselSolver/FullVector.h
@@ -71,7 +71,7 @@ namespace MbD {
 	inline double FullVector<double>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < (int)this->size(); i++)
 		{
 			double element = this->at(i);
 			sum += element * element;
@@ -92,7 +92,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < (int)this->size(); i++) {
 			this->at(i) = 0.0;
 		}
 	}
@@ -104,7 +104,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::atiplusFullVector(int i1, std::shared_ptr<FullVector<T>> fullVec)
 	{
-		for (int ii = 0; ii < fullVec->size(); ii++)
+		for (size_t ii = 0; ii < fullVec->size(); ii++)
 		{
 			auto i = i1 + ii;
 			this->at(i) += fullVec->at(ii);
@@ -113,7 +113,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::atiplusFullVectortimes(int i1, std::shared_ptr<FullVector<T>> fullVec, T factor)
 	{
-		for (int ii = 0; ii < fullVec->size(); ii++)
+		for (size_t ii = 0; ii < fullVec->size(); ii++)
 		{
 			auto i = i1 + ii;
 			this->at(i) += fullVec->at(ii) * factor;
@@ -122,7 +122,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::equalSelfPlusFullVectortimes(std::shared_ptr<FullVector<T>> fullVec, T factor)
 	{
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			this->atiplusNumber(i, fullVec->at(i) * factor);
 		}
@@ -131,7 +131,7 @@ namespace MbD {
 	inline double FullVector<double>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < (int)this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -156,7 +156,7 @@ namespace MbD {
 	inline double FullVector<T>::length()
 	{
 		double ssq = 0.0;
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double elem = this->at(i);
 			ssq += elem * elem;
@@ -173,7 +173,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::conditionSelfWithTol(double tol)
 	{
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < (int)this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -205,7 +205,7 @@ namespace MbD {
 		//"Test if elements are increasing."
 		//"Ok if spoilers are less than tol."
 		auto next = this->at(0);
-		for (int i = 1; i < this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			auto previous = next;
 			next = this->at(i);
@@ -219,7 +219,7 @@ namespace MbD {
 		//"Test if elements are increasing."
 		//"Ok if spoilers are less than tol."
 		auto next = this->at(0);
-		for (int i = 1; i < this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			auto previous = next;
 			next = this->at(i);
@@ -232,7 +232,7 @@ namespace MbD {
 	{
 		s << "FullVec{";
 		s << this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < (int)this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}

--- a/OndselSolver/FullVector.h
+++ b/OndselSolver/FullVector.h
@@ -71,7 +71,7 @@ namespace MbD {
 	inline double FullVector<double>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (size_t i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			sum += element * element;
@@ -92,7 +92,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::zeroSelf()
 	{
-		for (size_t i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i) = 0.0;
 		}
 	}
@@ -131,7 +131,7 @@ namespace MbD {
 	inline double FullVector<double>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (size_t i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -173,7 +173,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::conditionSelfWithTol(double tol)
 	{
-		for (size_t i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;

--- a/OndselSolver/FunctionWithManyArgs.cpp
+++ b/OndselSolver/FunctionWithManyArgs.cpp
@@ -33,7 +33,7 @@ FunctionWithManyArgs::FunctionWithManyArgs(Symsptr term, Symsptr term1, Symsptr 
 
 FunctionWithManyArgs::FunctionWithManyArgs(std::shared_ptr<std::vector<Symsptr>> _terms) {
 	terms = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < _terms->size(); i++)
+	for (size_t i = 0; i < _terms->size(); i++)
 		terms->push_back(_terms->at(i));
 }
 

--- a/OndselSolver/GeneralSpline.cpp
+++ b/OndselSolver/GeneralSpline.cpp
@@ -245,14 +245,14 @@ std::ostream& MbD::GeneralSpline::printOn(std::ostream& s) const
 	s << degree << ", " << std::endl;
 	s << "xs{";
 	s << xs->at(0);
-	for (int i = 1; i < xs->size(); i++)
+	for (size_t i = 1; i < xs->size(); i++)
 	{
 		s << ", " << xs->at(i);
 	}
 	s << "}, " << std::endl;
 	s << "ys{";
 	s << ys->at(0);
-	for (int i = 1; i < ys->size(); i++)
+	for (size_t i = 1; i < ys->size(); i++)
 	{
 		s << ", " << ys->at(i);
 	}

--- a/OndselSolver/Item.h
+++ b/OndselSolver/Item.h
@@ -32,6 +32,7 @@ namespace MbD {
 	public:
 		Item();
 		Item(const char* str);
+		virtual ~Item() {}
 		virtual System* root();
 		void noop();
 

--- a/OndselSolver/MBDynItem.h
+++ b/OndselSolver/MBDynItem.h
@@ -24,6 +24,7 @@ namespace MbD {
 	{
 		//
 	public:
+		virtual ~MBDynItem() {}
 		virtual MBDynSystem* root();
 
 		virtual void initialize();

--- a/OndselSolver/MBDynSystem.cpp
+++ b/OndselSolver/MBDynSystem.cpp
@@ -249,7 +249,7 @@ void MbD::MBDynSystem::eraseComments(std::vector<std::string>& lines)
 			lines[i] = line.substr(0, it);
 		}
 	}
-	for (size_t i = lines.size() - 1; i >= 0; i--) {
+	for (int i = lines.size() - 1; i >= 0; i--) {
 		auto& line = lines[i];
 		auto it = std::find_if(line.begin(), line.end(), [](unsigned char ch) { return !std::isspace(ch); });
 		if (it == line.end()) lines.erase(lines.begin() + i);

--- a/OndselSolver/MBDynSystem.cpp
+++ b/OndselSolver/MBDynSystem.cpp
@@ -151,7 +151,7 @@ void MbD::MBDynSystem::outputFiles()
 	auto asmtMotions = asmtAsm->motions;
 	std::ofstream os(movFile);
 	os << std::setprecision(std::numeric_limits<double>::digits10 + 1);
-	for (int i = 1; i < asmtTimes->size(); i++)
+	for (size_t i = 1; i < asmtTimes->size(); i++)
 	{
 		for (auto& node : *nodes) {
 			node->outputLine(i, os);
@@ -241,7 +241,7 @@ void MbD::MBDynSystem::readElementsBlock(std::vector<std::string>& lines)
 
 void MbD::MBDynSystem::eraseComments(std::vector<std::string>& lines)
 {
-	for (int i = 0; i < lines.size(); i++)
+	for (size_t i = 0; i < lines.size(); i++)
 	{
 		auto line = lines[i];
 		auto it = line.find('#');
@@ -249,7 +249,7 @@ void MbD::MBDynSystem::eraseComments(std::vector<std::string>& lines)
 			lines[i] = line.substr(0, it);
 		}
 	}
-	for (int i = lines.size() - 1; i >= 0; i--) {
+	for (size_t i = lines.size() - 1; i >= 0; i--) {
 		auto& line = lines[i];
 		auto it = std::find_if(line.begin(), line.end(), [](unsigned char ch) { return !std::isspace(ch); });
 		if (it == line.end()) lines.erase(lines.begin() + i);

--- a/OndselSolver/MarkerFrame.cpp
+++ b/OndselSolver/MarkerFrame.cpp
@@ -42,7 +42,7 @@ void MarkerFrame::initializeLocally()
 {
 	pprOmOpEpE = EulerParameters<double>::ppApEpEtimesColumn(rpmp);
 	ppAOmpEpE = EulerParameters<double>::ppApEpEtimesMatrix(aApm);
-	for (int i = 0; i < endFrames->size(); i++)
+	for (size_t i = 0; i < endFrames->size(); i++)
 	{
 		auto eFrmqc = std::dynamic_pointer_cast<EndFrameqc>(endFrames->at(i));
 		if (eFrmqc) {

--- a/OndselSolver/MatrixSolver.h
+++ b/OndselSolver/MatrixSolver.h
@@ -20,6 +20,7 @@ namespace MbD {
         //m n matrixA answerX rightHandSideB rowOrder colOrder rowScalings pivotValues singularPivotTolerance millisecondsToRun 
     public:
         MatrixSolver(){}
+        virtual ~MatrixSolver() {}
         void initialize() override;
         void setSystem(Solver* sys) override;
         virtual FColDsptr solvewithsaveOriginal(SpMatDsptr spMat, FColDsptr fullCol, bool saveOriginal);

--- a/OndselSolver/Numeric.h
+++ b/OndselSolver/Numeric.h
@@ -27,7 +27,7 @@ namespace MbD {
     {
         T previous, next;
         next = vec->at(0);
-        for (size_t i = 1; i < vec->size(); i++)
+        for (std::size_t i = 1; i < vec->size(); i++)
         {
             previous = next;
             next = vec->at(i);

--- a/OndselSolver/Numeric.h
+++ b/OndselSolver/Numeric.h
@@ -27,7 +27,7 @@ namespace MbD {
     {
         T previous, next;
         next = vec->at(0);
-        for (int i = 1; i < vec->size(); i++)
+        for (size_t i = 1; i < vec->size(); i++)
         {
             previous = next;
             next = vec->at(i);

--- a/OndselSolver/PiecewiseFunction.cpp
+++ b/OndselSolver/PiecewiseFunction.cpp
@@ -70,7 +70,7 @@ Symsptr MbD::PiecewiseFunction::integrateWRT(Symsptr var)
 		std::back_inserter(*integrals),
 		[var](auto& func) { return func->integrateWRT(var); }
 	);
-	for (int i = 0; i < transitions->size(); i++)
+	for (size_t i = 0; i < transitions->size(); i++)
 	{
 		auto x = transitions->at(i)->getValue();
 		auto fi = integrals->at(i)->getValue(x);
@@ -85,7 +85,7 @@ Symsptr MbD::PiecewiseFunction::integrateWRT(Symsptr var)
 double MbD::PiecewiseFunction::getValue()
 {
 	auto xval = xx->getValue();
-	for (int i = 0; i < transitions->size(); i++)
+	for (size_t i = 0; i < transitions->size(); i++)
 	{
 		if (xval < transitions->at(i)->getValue()) {
 			return functions->at(i)->getValue();
@@ -99,14 +99,14 @@ std::ostream& MbD::PiecewiseFunction::printOn(std::ostream& s) const
 	s << "PiecewiseFunction(" << *xx << ", " << std::endl;
 	s << "functions{" << std::endl;
 	s << *functions->at(0) << std::endl;
-	for (int i = 1; i < functions->size(); i++)
+	for (size_t i = 1; i < functions->size(); i++)
 	{
 		s << *functions->at(i) << std::endl;
 	}
 	s << "}, " << std::endl;
 	s << "transitions{" << std::endl;
 	s << *transitions->at(0) << std::endl;
-	for (int i = 1; i < transitions->size(); i++)
+	for (size_t i = 1; i < transitions->size(); i++)
 	{
 		s << *transitions->at(i) << std::endl;
 	}

--- a/OndselSolver/Polynomial.cpp
+++ b/OndselSolver/Polynomial.cpp
@@ -32,7 +32,7 @@ MbD::Polynomial::Polynomial(Symsptr var, std::shared_ptr<std::vector<Symsptr>> c
 Symsptr MbD::Polynomial::expandUntil(Symsptr sptr, std::shared_ptr<std::unordered_set<Symsptr>> set)
 {
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto coeff = coeffs->at(i);
 		auto newCoeff = coeff->expandUntil(coeff, set);
@@ -44,7 +44,7 @@ Symsptr MbD::Polynomial::expandUntil(Symsptr sptr, std::shared_ptr<std::unordere
 Symsptr MbD::Polynomial::simplifyUntil(Symsptr sptr, std::shared_ptr<std::unordered_set<Symsptr>> set)
 {
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto coeff = coeffs->at(i);
 		auto newCoeff = coeff->simplifyUntil(coeff, set);
@@ -58,7 +58,7 @@ Symsptr MbD::Polynomial::differentiateWRTx()
 	//Differentiate powers
 	if (coeffs->size() == 1) return sptrConstant(0.0);
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 1; i < coeffs->size(); i++)
+	for (size_t i = 1; i < coeffs->size(); i++)
 	{
 		auto newCoeff = i * coeffs->at(i)->getValue();
 		newCoeffs->push_back(sptrConstant(newCoeff));
@@ -80,7 +80,7 @@ Symsptr MbD::Polynomial::integrateWRT(Symsptr var)
 	assert(xx == var);
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
 	newCoeffs->push_back(sptrConstant(0.0));
-	for (int i = 0; i < coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto newCoeff = coeffs->at(i)->getValue() / (i + 1);
 		newCoeffs->push_back(sptrConstant(newCoeff));
@@ -93,7 +93,7 @@ double MbD::Polynomial::getValue()
 	auto xvalue = xx->getValue();
 	auto xpower = 1.0;
 	auto answer = 0.0;
-	for (int i = 0; i < coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		answer += coeffs->at(i)->getValue() * xpower;
 		xpower *= xvalue;
@@ -113,7 +113,7 @@ std::ostream& MbD::Polynomial::printOn(std::ostream& s) const
 	s << *xx << ", ";
 	s << "coeffs{";
 	s << *coeffs->at(0);
-	for (int i = 1; i < coeffs->size(); i++)
+	for (size_t i = 1; i < coeffs->size(); i++)
 	{
 		s << ", " << *coeffs->at(i);
 	}

--- a/OndselSolver/Product.cpp
+++ b/OndselSolver/Product.cpp
@@ -29,7 +29,7 @@ Symsptr MbD::Product::differentiateWRT(Symsptr var)
 		}
 	);
 	auto derivativeTerms = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < terms->size(); i++)
+	for (size_t i = 0; i < terms->size(); i++)
 	{
 		auto& derivative = derivatives->at(i);
 		auto newTermFunctions = std::make_shared<std::vector<Symsptr>>(*terms);
@@ -125,7 +125,7 @@ std::ostream& Product::printOn(std::ostream& s) const
 {
 	s << "(";
 	s << *(this->terms->at(0));
-	for (int i = 1; i < this->terms->size(); i++)
+	for (size_t i = 1; i < this->terms->size(); i++)
 	{
 		s << "*" << *(this->terms->at(i));
 	}
@@ -141,7 +141,7 @@ bool Product::isProduct()
 double Product::getValue()
 {
 	double answer = 1.0;
-	for (int i = 0; i < terms->size(); i++) answer *= terms->at(i)->getValue();
+	for (size_t i = 0; i < terms->size(); i++) answer *= terms->at(i)->getValue();
 	return answer;
 }
 

--- a/OndselSolver/RowTypeMatrix.h
+++ b/OndselSolver/RowTypeMatrix.h
@@ -35,7 +35,7 @@ namespace MbD {
 	template<typename T>
 	inline void RowTypeMatrix<T>::copyFrom(std::shared_ptr<RowTypeMatrix<T>> x)
 	{
-		for (int i = 0; i < x->size(); i++) {
+		for (size_t i = 0; i < x->size(); i++) {
 			this->at(i)->copyFrom(x->at(i));
 		}
 	}
@@ -43,7 +43,7 @@ namespace MbD {
 	//inline double RowTypeMatrix<T>::maxMagnitude()
 	//{
 	//	double max = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < this->size(); i++)
 	//	{
 	//		double element = this->at(i)->maxMagnitude();
 	//		if (max < element) max = element;

--- a/OndselSolver/Solver.h
+++ b/OndselSolver/Solver.h
@@ -16,6 +16,7 @@ namespace MbD {
 		//statistics
 	public:
 		void noop();
+		virtual ~Solver() {}
 		virtual void initialize();
 		virtual void initializeLocally();
 		virtual void initializeGlobally();

--- a/OndselSolver/SparseMatrix.h
+++ b/OndselSolver/SparseMatrix.h
@@ -98,7 +98,7 @@ namespace MbD {
 	inline double SparseMatrix<T>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			sum += this->at(i)->sumOfSquares();
 		}
@@ -107,7 +107,7 @@ namespace MbD {
 	template<>
 	inline void SparseMatrix<double>::zeroSelf()
 	{
-		for (int i = 0; i < this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->zeroSelf();
 		}
 	}
@@ -119,7 +119,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::atijplusFullColumn(int i, int j, FColsptr<T> fullCol)
 	{
-		for (int ii = 0; ii < fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->atijplusNumber(i + ii, j, fullCol->at(ii));
 		}
@@ -127,7 +127,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::atijminusFullColumn(int i, int j, FColDsptr fullCol)
 	{
-		for (int ii = 0; ii < fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->atijminusNumber(i + ii, j, fullCol->at(ii));
 		}
@@ -191,7 +191,7 @@ namespace MbD {
 	inline double SparseMatrix<T>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i)->maxMagnitude();
 			if (max < element) max = element;
@@ -202,7 +202,7 @@ namespace MbD {
 	inline std::ostream& SparseMatrix<T>::printOn(std::ostream& s) const
 	{
 		s << "SpMat[" << std::endl;
-		for (int i = 0; i < this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			s << *(this->at(i)) << std::endl;
 		}
@@ -229,7 +229,7 @@ namespace MbD {
 		//"Just evaluate quickly."
 
 		auto answer = clonesptr();
-		for (int i = 0; i < answer->size(); i++)
+		for (size_t i = 0; i < answer->size(); i++)
 		{
 			answer->atiput(i, answer->at(i)->plusSparseRow(spMat->at(i)));
 		}
@@ -243,7 +243,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::magnifySelf(T factor)
 	{
-		for (int i = 0; i < this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->magnifySelf(factor);
 		}
 	}

--- a/OndselSolver/SparseRow.h
+++ b/OndselSolver/SparseRow.h
@@ -64,7 +64,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseRow<T>::atiplusFullRow(int j, FRowsptr<T> fullRow)
 	{
-		for (int jj = 0; jj < fullRow->size(); jj++)
+		for (size_t jj = 0; jj < fullRow->size(); jj++)
 		{
 			(*this)[j + jj] += fullRow->at(jj);
 		}
@@ -72,7 +72,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseRow<T>::atiminusFullRow(int j, FRowsptr<T> fullRow)
 	{
-		for (int jj = 0; jj < fullRow->size(); jj++)
+		for (size_t jj = 0; jj < fullRow->size(); jj++)
 		{
 			(*this)[j + jj] -= fullRow->at(jj);
 		}
@@ -80,7 +80,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseRow<T>::atiplusFullRowtimes(int j, FRowsptr<T> fullRow, double factor)
 	{
-		for (int jj = 0; jj < fullRow->size(); jj++)
+		for (size_t jj = 0; jj < fullRow->size(); jj++)
 		{
 			(*this)[j + jj] += fullRow->at(jj) * factor;
 		}

--- a/OndselSolver/SparseVector.h
+++ b/OndselSolver/SparseVector.h
@@ -34,6 +34,7 @@ namespace MbD {
 				this->insert(std::pair<const int, double>(index, value));
 			}
 		}
+		virtual ~SparseVector() {}
 		double rootMeanSquare();
 		int numberOfElements();
 		double sumOfSquares();

--- a/OndselSolver/Sum.cpp
+++ b/OndselSolver/Sum.cpp
@@ -128,7 +128,7 @@ bool Sum::isSum()
 double Sum::getValue()
 {
 	double answer = 0.0;
-	for (int i = 0; i < terms->size(); i++) answer += terms->at(i)->getValue();
+	for (size_t i = 0; i < terms->size(); i++) answer += terms->at(i)->getValue();
 	return answer;
 }
 
@@ -174,7 +174,7 @@ std::ostream& Sum::printOn(std::ostream& s) const
 {
 	s << "(";
 	s << *(this->terms->at(0));
-	for (int i = 1; i < this->terms->size(); i++)
+	for (size_t i = 1; i < this->terms->size(); i++)
 	{
 		s << " + " << *(this->terms->at(i));
 	}

--- a/OndselSolver/Symbolic.h
+++ b/OndselSolver/Symbolic.h
@@ -27,6 +27,7 @@ namespace MbD {
 	{
 	public:
 		Symbolic();
+		virtual ~Symbolic() {}
 		static Symsptr times(Symsptr arg, Symsptr arg1);
 		static Symsptr sum(Symsptr arg, Symsptr arg1);
 		static Symsptr raisedTo(Symsptr x, Symsptr y);

--- a/OndselSolver/SymbolicParser.cpp
+++ b/OndselSolver/SymbolicParser.cpp
@@ -487,7 +487,7 @@ void MbD::SymbolicParser::notifyat(std::string msg, int mrk)
 void MbD::SymbolicParser::combineStackTo(int pos)
 {
 	auto args = std::make_shared<std::vector<Symsptr>>();
-	while (stack->size() > pos) {
+	while (stack->size() > (size_t) pos) {
 		Symsptr arg = stack->top();
 		stack->pop();
 		args->push_back(arg);

--- a/OndselSolver/System.cpp
+++ b/OndselSolver/System.cpp
@@ -186,7 +186,7 @@ double System::maximumMass()
 double System::maximumMomentOfInertia()
 {
 	double max = 0.0;
-	for (int i = 0; i < parts->size(); i++)
+	for (size_t i = 0; i < parts->size(); i++)
 	{
 		auto& part = parts->at(i);
 		for (int j = 0; j < 3; j++)


### PR DESCRIPTION
Apply Werner changes manually.

Here are changes I did not implement because I wasn't sure. Please check them.

```
diff --git a/OndselSolver/Constraint.h b/OndselSolver/Constraint.h
index 3063632..3deadd4 100644
--- a/OndselSolver/Constraint.h
+++ b/OndselSolver/Constraint.h
@@ -21,6 +21,12 @@ namespace MbD {
 		Constraint();
 		Constraint(const char* str);
 
+		using Item::fillConstraints;
+		using Item::fillDispConstraints;
+		using Item::fillEssenConstraints;
+		using Item::fillPerpenConstraints;
+		using Item::fillRedundantConstraints;
+
 		virtual void addToJointForceI(FColDsptr col);
 		virtual void addToJointTorqueI(FColDsptr col);
 		void fillAccICIterJacob(SpMatDsptr mat) override;


diff --git a/OndselSolver/FullColumn.cpp b/OndselSolver/FullColumn.cpp
index b173b08..7a6d801 100644
--- a/OndselSolver/FullColumn.cpp
+++ b/OndselSolver/FullColumn.cpp
@@ -44,7 +44,7 @@ namespace MbD {
         return answer;
     }
     template<typename T>
-    FColsptr<T> FullColumn<T>::times(T a)
+    FColsptr<T> FullColumn<T>::times([[maybe_unused]]T a)
     {
 
diff --git a/OndselSolver/FullRow.h b/OndselSolver/FullRow.h
index 7dfe096..8fde092 100644
--- a/OndselSolver/FullRow.h
+++ b/OndselSolver/FullRow.h
@@ -54,7 +54,7 @@ namespace MbD {
 		return answer;
 	}
 	template<typename T>
-	inline FRowsptr<T> FullRow<T>::times(T a)
+	inline FRowsptr<T> FullRow<T>::times([[maybe_unused]]T a)
 	{
 		assert(false);
 	}

diff --git a/OndselSolver/MBDynBody.h b/OndselSolver/MBDynBody.h
index 99afed4..0ce8d70 100644
--- a/OndselSolver/MBDynBody.h
+++ b/OndselSolver/MBDynBody.h
@@ -13,6 +13,8 @@ namespace MbD {
     class MBDynBody : public MBDynElement
     {
     public:
+        using MBDynElement::parseMBDyn;
+
         void initialize() override;
         void parseMBDyn(std::string line);
         void readMass(std::vector<std::string>& args);

diff --git a/OndselSolver/MBDynJoint.h b/OndselSolver/MBDynJoint.h
index 09dc0fb..a6ed7d2 100644
--- a/OndselSolver/MBDynJoint.h
+++ b/OndselSolver/MBDynJoint.h
@@ -14,6 +14,8 @@ namespace MbD {
     class MBDynJoint : public MBDynElement
     {
     public:
+        using MBDynElement::parseMBDyn;
+
         void initialize() override;
         void parseMBDyn(std::string line);
         void readMarkerI(std::vector<std::string>& args);
diff --git a/OndselSolver/MBDynReference.h b/OndselSolver/MBDynReference.h
index 5867816..3289b49 100644
--- a/OndselSolver/MBDynReference.h
+++ b/OndselSolver/MBDynReference.h
@@ -14,6 +14,8 @@ namespace MbD {
 	class MBDynReference : public MBDynItem
 	{
 	public:
+        using MBDynItem::parseMBDyn;
+
 		void initialize() override;
 		void parseMBDyn(std::string line);
 		void readVelocity(std::vector<std::string>& args);
diff --git a/OndselSolver/MBDynStructural.h b/OndselSolver/MBDynStructural.h
index d38b3d3..7405b28 100644
--- a/OndselSolver/MBDynStructural.h
+++ b/OndselSolver/MBDynStructural.h
@@ -14,6 +14,8 @@ namespace MbD {
     {
     public:
         MBDynStructural();
+        using MBDynNode::parseMBDyn;
+
         void parseMBDyn(std::string line);
         void readVelocity(std::vector<std::string>& args);
         void readOmega(std::vector<std::string>& args);
```

