### PR TITLE
Fix various compiler warnings

### DIFF
--- a/OndselSolver/ASMTAnimationParameters.cpp
+++ b/OndselSolver/ASMTAnimationParameters.cpp
@@ -14,7 +14,7 @@ void MbD::ASMTAnimationParameters::parseASMT(std::vector<std::string>& lines)
 {
 	//int nframe, icurrent, istart, iend, framesPerSecond;
 	//bool isForward;
-	int pos = (int)lines[0].find_first_not_of("\t");
+	auto pos = lines[0].find_first_not_of("\t");
 	auto leadingTabs = lines[0].substr(0, pos);
 	assert(lines[0] == (leadingTabs + "nframe"));
 	lines.erase(lines.begin());

--- a/OndselSolver/ASMTAssembly.cpp
+++ b/OndselSolver/ASMTAssembly.cpp
@@ -894,9 +894,9 @@ double MbD::ASMTAssembly::calcCharacteristicTime()
 
 double MbD::ASMTAssembly::calcCharacteristicMass()
 {
-	auto n = (int)parts->size();
+	auto n = parts->size();
 	double sumOfSquares = 0.0;
-	for (int i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 	{
 		auto mass = parts->at(i)->principalMassMarker->mass;
 		sumOfSquares += mass * mass;
@@ -917,9 +917,9 @@ double MbD::ASMTAssembly::calcCharacteristicLength()
 		auto& mkrJ = markerMap->at(connector->markerJ);
 		lengths->push_back(mkrJ->rpmp()->length());
 	}
-	auto n = (int)lengths->size();
+	auto n = lengths->size();
 	double sumOfSquares = std::accumulate(lengths->begin(), lengths->end(), 0.0, [](double sum, double l) { return sum + l * l; });
-	auto unitLength = std::sqrt(sumOfSquares / std::max((int)n, 1));
+	auto unitLength = std::sqrt(sumOfSquares / std::max(n, size_t(1)));
 	if (unitLength <= 0) unitLength = 1.0;
 	return unitLength;
 }
@@ -1285,13 +1285,13 @@ void MbD::ASMTAssembly::storeOnTimeSeries(std::ofstream& os)
 	if (times->empty()) return;
 	os << "TimeSeries" << std::endl;
 	os << "Number\tInput\t";
-	for (int i = 1; i < (int)times->size(); i++)
+	for (size_t i = 1; i < times->size(); i++)
 	{
 		os << i << '\t';
 	}
 	os << std::endl;
 	os << "Time\tInput\t";
-	for (int i = 1; i < (int)times->size(); i++)
+	for (size_t i = 1; i < times->size(); i++)
 	{
 		os << times->at(i) << '\t';
 	}

--- a/OndselSolver/ASMTAssembly.cpp
+++ b/OndselSolver/ASMTAssembly.cpp
@@ -1054,7 +1054,7 @@ void MbD::ASMTAssembly::runKINEMATIC()
 	try {
 		mbdSystem->runKINEMATIC(mbdSystem);
 	}
-	catch (SimulationStoppingError ex) {
+	catch (const SimulationStoppingError& ex) {
 
 	}
 }

--- a/OndselSolver/ASMTItem.cpp
+++ b/OndselSolver/ASMTItem.cpp
@@ -229,7 +229,7 @@ void MbD::ASMTItem::storeOnLevelBool(std::ofstream& os, int level, bool value)
 void MbD::ASMTItem::storeOnLevelArray(std::ofstream& os, int level, std::vector<double> array)
 {
 	storeOnLevelTabs(os, level);
-	for (int i = 0; i < (int)array.size(); i++)
+	for (size_t i = 0; i < array.size(); i++)
 	{
 		os << array[i] << '\t';
 	}

--- a/OndselSolver/ASMTItemIJ.cpp
+++ b/OndselSolver/ASMTItemIJ.cpp
@@ -108,37 +108,37 @@ void MbD::ASMTItemIJ::storeOnLevel(std::ofstream& os, int level)
 void MbD::ASMTItemIJ::storeOnTimeSeries(std::ofstream& os)
 {
 	os << "FXonI\t";
-	for (int i = 0; i < (int)fxs->size(); i++)
+	for (size_t i = 0; i < fxs->size(); i++)
 	{
 		os << fxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "FYonI\t";
-	for (int i = 0; i < (int)fys->size(); i++)
+	for (size_t i = 0; i < fys->size(); i++)
 	{
 		os << fys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "FZonI\t";
-	for (int i = 0; i < (int)fzs->size(); i++)
+	for (size_t i = 0; i < fzs->size(); i++)
 	{
 		os << fzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TXonI\t";
-	for (int i = 0; i < (int)txs->size(); i++)
+	for (size_t i = 0; i < txs->size(); i++)
 	{
 		os << txs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TYonI\t";
-	for (int i = 0; i < (int)tys->size(); i++)
+	for (size_t i = 0; i < tys->size(); i++)
 	{
 		os << tys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "TZonI\t";
-	for (int i = 0; i < (int)tzs->size(); i++)
+	for (size_t i = 0; i < tzs->size(); i++)
 	{
 		os << tzs->at(i) << '\t';
 	}

--- a/OndselSolver/ASMTPrincipalMassMarker.cpp
+++ b/OndselSolver/ASMTPrincipalMassMarker.cpp
@@ -19,7 +19,7 @@ MbD::ASMTPrincipalMassMarker::ASMTPrincipalMassMarker()
 
 void MbD::ASMTPrincipalMassMarker::parseASMT(std::vector<std::string>& lines)
 {
-	int pos = (int)lines[0].find_first_not_of("\t");
+	auto pos = lines[0].find_first_not_of("\t");
 	auto leadingTabs = lines[0].substr(0, pos);
 	assert(lines[0] == (leadingTabs + "Name"));
 	lines.erase(lines.begin());

--- a/OndselSolver/ASMTSimulationParameters.cpp
+++ b/OndselSolver/ASMTSimulationParameters.cpp
@@ -14,7 +14,7 @@ void MbD::ASMTSimulationParameters::parseASMT(std::vector<std::string>& lines)
 {
 	//tstart, tend, hmin, hmax, hout, errorTol;
 
-	int pos = (int)lines[0].find_first_not_of("\t");
+	auto pos = lines[0].find_first_not_of("\t");
 	auto leadingTabs = lines[0].substr(0, pos);
 	assert(lines[0] == (leadingTabs + "tstart"));
 	lines.erase(lines.begin());

--- a/OndselSolver/ASMTSpatialContainer.cpp
+++ b/OndselSolver/ASMTSpatialContainer.cpp
@@ -603,109 +603,109 @@ void MbD::ASMTSpatialContainer::storeOnLevelRefSurfaces(std::ofstream& os, int l
 void MbD::ASMTSpatialContainer::storeOnTimeSeries(std::ofstream& os)
 {
 	os << "X\t";
-	for (int i = 0; i < (int)xs->size(); i++)
+	for (size_t i = 0; i < xs->size(); i++)
 	{
 		os << xs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Y\t";
-	for (int i = 0; i < (int)ys->size(); i++)
+	for (size_t i = 0; i < ys->size(); i++)
 	{
 		os << ys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Z\t";
-	for (int i = 0; i < (int)zs->size(); i++)
+	for (size_t i = 0; i < zs->size(); i++)
 	{
 		os << zs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryantx\t";
-	for (int i = 0; i < (int)bryxs->size(); i++)
+	for (size_t i = 0; i < bryxs->size(); i++)
 	{
 		os << bryxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryanty\t";
-	for (int i = 0; i < (int)bryys->size(); i++)
+	for (size_t i = 0; i < bryys->size(); i++)
 	{
 		os << bryys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "Bryantz\t";
-	for (int i = 0; i < (int)bryzs->size(); i++)
+	for (size_t i = 0; i < bryzs->size(); i++)
 	{
 		os << bryzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VX\t";
-	for (int i = 0; i < (int)vxs->size(); i++)
+	for (size_t i = 0; i < vxs->size(); i++)
 	{
 		os << vxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VY\t";
-	for (int i = 0; i < (int)vys->size(); i++)
+	for (size_t i = 0; i < vys->size(); i++)
 	{
 		os << vys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "VZ\t";
-	for (int i = 0; i < (int)vzs->size(); i++)
+	for (size_t i = 0; i < vzs->size(); i++)
 	{
 		os << vzs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaX\t";
-	for (int i = 0; i < (int)omexs->size(); i++)
+	for (size_t i = 0; i < omexs->size(); i++)
 	{
 		os << omexs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaY\t";
-	for (int i = 0; i < (int)omeys->size(); i++)
+	for (size_t i = 0; i < omeys->size(); i++)
 	{
 		os << omeys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "OmegaZ\t";
-	for (int i = 0; i < (int)omezs->size(); i++)
+	for (size_t i = 0; i < omezs->size(); i++)
 	{
 		os << omezs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AX\t";
-	for (int i = 0; i < (int)axs->size(); i++)
+	for (size_t i = 0; i < axs->size(); i++)
 	{
 		os << axs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AY\t";
-	for (int i = 0; i < (int)ays->size(); i++)
+	for (size_t i = 0; i < ays->size(); i++)
 	{
 		os << ays->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AZ\t";
-	for (int i = 0; i < (int)azs->size(); i++)
+	for (size_t i = 0; i < azs->size(); i++)
 	{
 		os << azs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaX\t";
-	for (int i = 0; i < (int)alpxs->size(); i++)
+	for (size_t i = 0; i < alpxs->size(); i++)
 	{
 		os << alpxs->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaY\t";
-	for (int i = 0; i < (int)alpys->size(); i++)
+	for (size_t i = 0; i < alpys->size(); i++)
 	{
 		os << alpys->at(i) << '\t';
 	}
 	os << std::endl;
 	os << "AlphaZ\t";
-	for (int i = 0; i < (int)alpzs->size(); i++)
+	for (size_t i = 0; i < alpzs->size(); i++)
 	{
 		os << alpzs->at(i) << '\t';
 	}

--- a/OndselSolver/Array.h
+++ b/OndselSolver/Array.h
@@ -72,14 +72,14 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::copyFrom(std::shared_ptr<Array<T>> x)
 	{
-		for (int i = 0; i < (int)x->size(); i++) {
+		for (size_t i = 0; i < x->size(); i++) {
 			this->at(i) = x->at(i);
 		}
 	}
 	template<typename T>
 	inline void Array<T>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i) = (T)0;
 		}
 	}
@@ -104,7 +104,7 @@ namespace MbD {
 	//inline double Array<double>::maxMagnitude()
 	//{
 	//	double max = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < >size(); i++)
 	//	{
 	//		auto element = this->at(i);
 	//		if (element < 0.0) element = -element;
@@ -116,7 +116,7 @@ namespace MbD {
 	inline double Array<T>::maxMagnitudeOfVector()
 	{
 		double answer = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double mag = std::abs(this->at(i));
 			if (answer < mag) answer = mag;
@@ -126,9 +126,9 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::equalArrayAt(std::shared_ptr<Array<T>> array, int i)
 	{
-		for (int ii = 0; ii < (int)this->size(); ii++)
+		for (size_t ii = 0; ii < this->size(); ii++)
 		{
-			this->at(ii) = array->at((int)i + ii);
+			this->at(ii) = array->at(i + ii);
 		}
 	}
 	//template<>
@@ -148,7 +148,7 @@ namespace MbD {
 	//template<>
 	//inline void Array<double>::conditionSelfWithTol(double tol)
 	//{
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < >size(); i++)
 	//	{
 	//		double element = this->at(i);
 	//		if (element < 0.0) element = -element;
@@ -164,7 +164,7 @@ namespace MbD {
 	//inline double Array<double>::length()
 	//{
 	//	double ssq = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < >size(); i++)
 	//	{
 	//		double elem = this->at(i);
 	//		ssq += elem * elem;
@@ -174,7 +174,7 @@ namespace MbD {
 	template<typename T>
 	inline void Array<T>::magnifySelf(T factor)
 	{
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			this->atitimes(i, factor);
 		}

--- a/OndselSolver/ConstraintIJ.cpp
+++ b/OndselSolver/ConstraintIJ.cpp
@@ -11,7 +11,7 @@
 
 using namespace MbD;
 
-ConstraintIJ::ConstraintIJ(EndFrmsptr frmi, EndFrmsptr frmj) : frmI(frmi), frmJ(frmj), Constraint()
+ConstraintIJ::ConstraintIJ(EndFrmsptr frmi, EndFrmsptr frmj) : Constraint(), frmI(frmi), frmJ(frmj)
 {
 }
 

--- a/OndselSolver/DiagonalMatrix.h
+++ b/OndselSolver/DiagonalMatrix.h
@@ -49,9 +49,9 @@ namespace MbD {
 	template<>
 	inline DiagMatDsptr DiagonalMatrix<double>::times(double factor)
 	{
-		auto nrow = (int)this->size();
+		auto nrow = this->size();
 		auto answer = std::make_shared<DiagonalMatrix<double>>(nrow);
-		for (int i = 0; i < nrow; i++)
+		for (size_t i = 0; i < nrow; i++)
 		{
 			answer->at(i) = this->at(i) * factor;
 		}
@@ -60,7 +60,7 @@ namespace MbD {
 	template<typename T>
 	inline void DiagonalMatrix<T>::atiputDiagonalMatrix(int i, std::shared_ptr<DiagonalMatrix<T>> diagMat)
 	{
-		for (int ii = 0; ii < (int)diagMat->size(); ii++)
+		for (size_t ii = 0; ii < diagMat->size(); ii++)
 		{
 			this->at(i + ii) = diagMat->at(ii);
 		}
@@ -75,9 +75,9 @@ namespace MbD {
 	{
 		//"a*b = a(i,j)b(j) sum j."
 
-		auto nrow = (int)this->size();
+		auto nrow = this->size();
 		auto answer = std::make_shared<FullColumn<T>>(nrow);
-		for (int i = 0; i < nrow; i++)
+		for (size_t i = 0; i < nrow; i++)
 		{
 			answer->at(i) = this->at(i) * fullCol->at(i);
 		}
@@ -86,9 +86,9 @@ namespace MbD {
 	template<typename T>
 	inline FMatsptr<T> DiagonalMatrix<T>::timesFullMatrix(FMatsptr<T> fullMat)
 	{
-		auto nrow = (int)this->size();
+		auto nrow = this->size();
 		auto answer = std::make_shared<FullMatrix<T>>(nrow);
-		for (int i = 0; i < nrow; i++)
+		for (size_t i = 0; i < nrow; i++)
 		{
 			answer->at(i) = fullMat->at(i)->times(this->at(i));
 		}
@@ -98,7 +98,7 @@ namespace MbD {
 	inline double DiagonalMatrix<double>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			sum += element * element;
@@ -114,7 +114,7 @@ namespace MbD {
 	template<>
 	inline void DiagonalMatrix<double>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i) = 0.0;
 		}
 	}
@@ -122,7 +122,7 @@ namespace MbD {
 	inline double DiagonalMatrix<double>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -141,7 +141,7 @@ namespace MbD {
 	{
 		s << "DiagMat[";
 		s << this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}

--- a/OndselSolver/DifferenceOperator.cpp
+++ b/OndselSolver/DifferenceOperator.cpp
@@ -36,7 +36,7 @@ void DifferenceOperator::calcOperatorMatrix()
 	try {
 		operatorMatrix = CREATE<LDUFullMatParPv>::With()->inversesaveOriginal(taylorMatrix, false);
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 	}
 }
 

--- a/OndselSolver/DifferenceOperator.cpp
+++ b/OndselSolver/DifferenceOperator.cpp
@@ -18,7 +18,7 @@ using namespace MbD;
 
 FRowDsptr DifferenceOperator::OneOverFactorials = []() {
 	auto oneOverFactorials = std::make_shared<FullRow<double>>(10);
-	for (int i = 0; i < (int)oneOverFactorials->size(); i++)
+	for (size_t i = 0; i < oneOverFactorials->size(); i++)
 	{
 		oneOverFactorials->at(i) = 1.0 / std::tgamma(i + 1);
 	}

--- a/OndselSolver/FullColumn.h
+++ b/OndselSolver/FullColumn.h
@@ -59,9 +59,9 @@ namespace MbD {
 	template<typename T>
 	inline FColsptr<T> FullColumn<T>::plusFullColumn(FColsptr<T> fullCol)
 	{
-		int n = (int) this->size();
+		auto n =  this->size();
 		auto answer = std::make_shared<FullColumn<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) + fullCol->at(i);
 		}
 		return answer;
@@ -69,9 +69,9 @@ namespace MbD {
 	template<typename T>
 	inline FColsptr<T> FullColumn<T>::minusFullColumn(FColsptr<T> fullCol)
 	{
-		int n = (int) this->size();
+		auto n =  this->size();
 		auto answer = std::make_shared<FullColumn<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) - fullCol->at(i);
 		}
 		return answer;
@@ -79,9 +79,9 @@ namespace MbD {
 	template<>
 	inline FColDsptr FullColumn<double>::times(double a)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullColumn<double>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) * a;
 		}
 		return answer;
@@ -99,7 +99,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullColumn<T>::atiputFullColumn(int i, FColsptr<T> fullCol)
 	{
-		for (int ii = 0; ii < (int)fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->at(i + ii) = fullCol->at(ii);
 		}
@@ -107,7 +107,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullColumn<T>::atiplusFullColumn(int i, FColsptr<T> fullCol)
 	{
-		for (int ii = 0; ii < (int)fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->at(i + ii) += fullCol->at(ii);
 		}
@@ -116,7 +116,7 @@ namespace MbD {
 	inline void FullColumn<T>::equalSelfPlusFullColumnAt(FColsptr<T> fullCol, int ii)
 	{
 		//self is subcolumn of fullCol
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			this->at(i) += fullCol->at(ii + i);
 		}
@@ -124,9 +124,9 @@ namespace MbD {
 	template<typename T>
 	inline void FullColumn<T>::atiminusFullColumn(int i1, FColsptr<T> fullCol)
 	{
-		for (int ii = 0; ii < (int)fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
-			int i = i1 + ii;
+			size_t i = i1 + ii;
 			this->at(i) -= fullCol->at(ii);
 		}
 	}
@@ -134,7 +134,7 @@ namespace MbD {
 	inline void FullColumn<T>::equalFullColumnAt(FColsptr<T> fullCol, int i)
 	{
 		this->equalArrayAt(fullCol, i);
-		//for (int ii = 0; ii < this->size(); ii++)
+		//for (size_t ii = 0; ii < this->size(); ii++)
 		//{
 		//	this->at(ii) = fullCol->at(i + ii);
 		//}
@@ -142,9 +142,9 @@ namespace MbD {
 	template<>
 	inline FColDsptr FullColumn<double>::copy()
 	{
-		auto n = (int) this->size();
+		auto n =  this->size();
 		auto answer = std::make_shared<FullColumn<double>>(n);
-		for (int i = 0; i < n; i++)
+		for (size_t i = 0; i < n; i++)
 		{
 			answer->at(i) = this->at(i);
 		}
@@ -158,9 +158,9 @@ namespace MbD {
 	template<typename T>
 	inline void FullColumn<T>::atiplusFullColumntimes(int i1, FColsptr<T> fullCol, T factor)
 	{
-		for (int ii = 0; ii < (int)fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
-			int i = i1 + ii;
+			size_t i = i1 + ii;
 			this->at(i) += fullCol->at(ii) * factor;
 		}
 	}
@@ -194,7 +194,7 @@ namespace MbD {
 	//{
 	//	auto n = this->size();
 	//	auto answer = std::make_shared<FullColumn<Symsptr>>(n);
-	//	for (int i = 0; i < n; i++)
+	//	for (size_t i = 0; i < n; i++)
 	//	{
 	//		auto func = this->at(i);
 	//		answer->at(i) = func->simplified(func);
@@ -210,9 +210,9 @@ namespace MbD {
 	template<typename T>
 	inline double FullColumn<T>::dot(std::shared_ptr<FullVector<T>> vec)
 	{
-		int n = (int)this->size();
+		size_t n = this->size();
 		double answer = 0.0;
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer += this->at(i) * vec->at(i);
 		}
 		return answer;
@@ -220,12 +220,12 @@ namespace MbD {
 	template<typename T>
 	inline std::shared_ptr<FullVector<T>> FullColumn<T>::dot(std::shared_ptr<std::vector<std::shared_ptr<FullColumn<T>>>> vecvec)
 	{
-		int ncol = (int)this->size();
+		size_t ncol = this->size();
 		auto nelem = vecvec->at(0)->size();
 		auto answer = std::make_shared<FullVector<T>>(nelem);
-		for (int k = 0; k < nelem; k++) {
+		for (size_t k = 0; k < nelem; k++) {
 			auto sum = 0.0;
-			for (int i = 0; i < ncol; i++)
+			for (size_t i = 0; i < ncol; i++)
 			{
 				sum += this->at(i) * vecvec->at(i)->at(k);
 			}
@@ -238,7 +238,7 @@ namespace MbD {
 	{
 		s << "FullCol{";
 		s << this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}

--- a/OndselSolver/FullMatrix.h
+++ b/OndselSolver/FullMatrix.h
@@ -338,22 +338,22 @@ namespace MbD {
 	template<>
 	inline void FullMatrix<double>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->zeroSelf();
 		}
 	}
 	template<>
 	inline void FullMatrix<double>::identity() {
 		this->zeroSelf();
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->at(i) = 1.0;
 		}
 	}
 	template<typename T>
 	inline FColsptr<T> FullMatrix<T>::column(int j) {
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullColumn<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i)->at(j);
 		}
 		return answer;
@@ -401,9 +401,9 @@ namespace MbD {
 	template<typename T>
 	inline FMatsptr<T> FullMatrix<T>::plusFullMatrix(FMatsptr<T> fullMat)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullMatrix<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i)->plusFullRow(fullMat->at(i));
 		}
 		return answer;
@@ -411,9 +411,9 @@ namespace MbD {
 	template<typename T>
 	inline FMatsptr<T> FullMatrix<T>::minusFullMatrix(FMatsptr<T> fullMat)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullMatrix<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i)->minusFullRow(fullMat->at(i));
 		}
 		return answer;
@@ -440,9 +440,9 @@ namespace MbD {
 	template<typename T>
 	inline void FullMatrix<T>::symLowerWithUpper()
 	{
-		int n = (int)this->size();
-		for (int i = 0; i < n; i++) {
-			for (int j = i + 1; j < n; j++) {
+		auto n = this->size();
+		for (size_t i = 0; i < n; i++) {
+			for (size_t j = i + 1; j < n; j++) {
 				this->at(j)->at(i) = this->at(i)->at(j);
 			}
 		}
@@ -486,7 +486,7 @@ namespace MbD {
 	inline double FullMatrix<double>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			sum += this->at(i)->sumOfSquares();
 		}
@@ -506,9 +506,9 @@ namespace MbD {
 	template<typename T>
 	inline FMatsptr<T> FullMatrix<T>::copy()
 	{
-		auto m = (int)this->size();
+		auto m = this->size();
 		auto answer = std::make_shared<FullMatrix<T>>(m);
-		for (int i = 0; i < m; i++)
+		for (size_t i = 0; i < m; i++)
 		{
 			answer->at(i) = this->at(i)->copy();
 		}
@@ -517,9 +517,9 @@ namespace MbD {
 	template<typename T>
 	inline FullMatrix<T> FullMatrix<T>::operator+(const FullMatrix<T> fullMat)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = FullMatrix<T>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer.at(i) = this->at(i)->plusFullRow(fullMat.at(i));
 		}
 		return answer;
@@ -533,7 +533,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullMatrix<T>::magnifySelf(T factor)
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->magnifySelf(factor);
 		}
 	}
@@ -541,7 +541,7 @@ namespace MbD {
 	inline std::ostream& FullMatrix<T>::printOn(std::ostream& s) const
 	{
 		s << "FullMat[" << std::endl;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			s << *(this->at(i)) << std::endl;
 		}
@@ -560,7 +560,7 @@ namespace MbD {
 		auto qE = std::make_shared<EulerParameters<T>>(4);
 		qE->initialize();
 		auto OneMinusTraceDivFour = (1.0 - traceA) / 4.0;
-		for (int i = 0; i < 3; i++)
+		for (size_t i = 0; i < 3; i++)
 		{
 			dumSq = this->at(i)->at(i) / 2.0 + OneMinusTraceDivFour;
 			dum = (dumSq > 0.0) ? std::sqrt(dumSq) : 0.0;
@@ -571,7 +571,7 @@ namespace MbD {
 		qE->atiput(3, dum);
 		T max = 0.0;
 		int maxE = -1;
-		for (int i = 0; i < 4; i++)
+		for (size_t i = 0; i < 4; i++)
 		{
 			auto num = qE->at(i);
 			if (max < num) {
@@ -612,7 +612,7 @@ namespace MbD {
 	inline T FullMatrix<T>::trace()
 	{
 		T trace = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			trace += this->at(i)->at(i);
 		}
@@ -622,7 +622,7 @@ namespace MbD {
 	inline double FullMatrix<T>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i)->maxMagnitude();
 			if (max < element) max = element;
@@ -689,9 +689,9 @@ namespace MbD {
 		auto tol = ratio * maxMag;
 		auto nrow = this->nrow();
 		if (nrow == this->ncol()) {
-			for (int i = 0; i < 3; i++)
+			for (size_t i = 0; i < 3; i++)
 			{
-				for (int j = i + 1; j < 3; j++)
+				for (size_t j = i + 1; j < 3; j++)
 				{
 					if (std::abs(this->at(i)->at(j)) > tol) return false;
 					if (std::abs(this->at(j)->at(i)) > tol) return false;

--- a/OndselSolver/FullRow.h
+++ b/OndselSolver/FullRow.h
@@ -61,9 +61,9 @@ namespace MbD {
 	template<>
 	inline FRowDsptr FullRow<double>::times(double a)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullRow<double>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) * a;
 		}
 		return answer;
@@ -81,9 +81,9 @@ namespace MbD {
 	template<typename T>
 	inline FRowsptr<T> FullRow<T>::plusFullRow(FRowsptr<T> fullRow)
 	{
-		int n = (int) this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullRow<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) + fullRow->at(i);
 		}
 		return answer;
@@ -91,9 +91,9 @@ namespace MbD {
 	template<typename T>
 	inline FRowsptr<T> FullRow<T>::minusFullRow(FRowsptr<T> fullRow)
 	{
-		int n = (int) this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullRow<T>>(n);
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer->at(i) = this->at(i) - fullRow->at(i);
 		}
 		return answer;
@@ -107,7 +107,7 @@ namespace MbD {
 	inline T FullRow<T>::timesFullColumn(FullColumn<T>* fullCol)
 	{
 		auto answer = this->at(0) * fullCol->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			answer += this->at(i) * fullCol->at(i);
 		}
@@ -142,9 +142,9 @@ namespace MbD {
 	template<>
 	inline FRowDsptr FullRow<double>::copy()
 	{
-		auto n = (int)this->size();
+		auto n = this->size();
 		auto answer = std::make_shared<FullRow<double>>(n);
-		for (int i = 0; i < n; i++)
+		for (size_t i = 0; i < n; i++)
 		{
 			answer->at(i) = this->at(i);
 		}
@@ -153,7 +153,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullRow<T>::atiplusFullRow(int j1, FRowsptr<T> fullRow)
 	{
-		for (int jj = 0; jj < fullRow->size(); jj++)
+		for (size_t jj = 0; jj < fullRow->size(); jj++)
 		{
 			auto j = j1 + jj;
 			this->at(j) += fullRow->at(jj);
@@ -163,9 +163,9 @@ namespace MbD {
 	inline FMatsptr<T> FullRow<T>::transposeTimesFullRow(FRowsptr<T> fullRow)
 	{
 		//"a*b = a(i)b(j)"
-		auto nrow = (int)this->size();
+		auto nrow = this->size();
 		auto answer = std::make_shared<FullMatrix<T>>(nrow);
-		for (int i = 0; i < nrow; i++)
+		for (size_t i = 0; i < nrow; i++)
 		{
 			answer->atiput(i, fullRow->times(this->at(i)));
 		}
@@ -174,9 +174,9 @@ namespace MbD {
 	template<typename T>
 	inline double FullRow<T>::dot(std::shared_ptr<FullVector<T>> vec)
 	{
-		int n = (int)this->size();
+		auto n = this->size();
 		double answer = 0.0;
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer += this->at(i) * vec->at(i);
 		}
 		return answer;
@@ -184,12 +184,12 @@ namespace MbD {
 	template<typename T>
 	inline std::shared_ptr<FullVector<T>> FullRow<T>::dot(std::shared_ptr<std::vector<std::shared_ptr<FullColumn<T>>>> vecvec)
 	{
-		auto ncol = (int)this->size();
+		auto ncol = this->size();
 		auto nelem = vecvec->at(0)->size();
 		auto answer = std::make_shared<FullVector<T>>(nelem);
-		for (int k = 0; k < (int)nelem; k++) {
+		for (size_t k = 0; k < nelem; k++) {
 			auto sum = 0.0;
-			for (int i = 0; i < ncol; i++)
+			for (size_t i = 0; i < ncol; i++)
 			{
 				sum += this->at(i) * vecvec->at(i)->at(k);
 			}
@@ -202,7 +202,7 @@ namespace MbD {
 	{
 		s << "FullRow{";
 		s << this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}
@@ -213,7 +213,7 @@ namespace MbD {
 	inline FRowsptr<T> FullRow<T>::timesFullMatrix(FMatsptr<T> fullMat)
 	{
 		FRowsptr<T> answer = fullMat->at(0)->times(this->at(0));
-		for (int j = 1; j < (int) this->size(); j++)
+		for (size_t j = 1; j < this->size(); j++)
 		{
 			answer->equalSelfPlusFullRowTimes(fullMat->at(j), this->at(j));
 		}

--- a/OndselSolver/FullVector.h
+++ b/OndselSolver/FullVector.h
@@ -50,9 +50,9 @@ namespace MbD {
 	template<typename T>
 	inline double FullVector<T>::dot(std::shared_ptr<FullVector<T>> vec)
 	{
-		int n = (int)this->size();
+		size_t n = this->size();
 		double answer = 0.0;
-		for (int i = 0; i < n; i++) {
+		for (size_t i = 0; i < n; i++) {
 			answer += this->at(i) * vec->at(i);
 		}
 		return answer;
@@ -71,7 +71,7 @@ namespace MbD {
 	inline double FullVector<double>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			sum += element * element;
@@ -92,7 +92,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i) = 0.0;
 		}
 	}
@@ -104,7 +104,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::atiplusFullVector(int i1, std::shared_ptr<FullVector<T>> fullVec)
 	{
-		for (int ii = 0; ii < (int)fullVec->size(); ii++)
+		for (size_t ii = 0; ii < fullVec->size(); ii++)
 		{
 			auto i = i1 + ii;
 			this->at(i) += fullVec->at(ii);
@@ -113,7 +113,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::atiplusFullVectortimes(int i1, std::shared_ptr<FullVector<T>> fullVec, T factor)
 	{
-		for (int ii = 0; ii < (int)fullVec->size(); ii++)
+		for (size_t ii = 0; ii < fullVec->size(); ii++)
 		{
 			auto i = i1 + ii;
 			this->at(i) += fullVec->at(ii) * factor;
@@ -122,7 +122,7 @@ namespace MbD {
 	template<typename T>
 	inline void FullVector<T>::equalSelfPlusFullVectortimes(std::shared_ptr<FullVector<T>> fullVec, T factor)
 	{
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			this->atiplusNumber(i, fullVec->at(i) * factor);
 		}
@@ -131,7 +131,7 @@ namespace MbD {
 	inline double FullVector<double>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -156,7 +156,7 @@ namespace MbD {
 	inline double FullVector<T>::length()
 	{
 		double ssq = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double elem = this->at(i);
 			ssq += elem * elem;
@@ -173,7 +173,7 @@ namespace MbD {
 	template<>
 	inline void FullVector<double>::conditionSelfWithTol(double tol)
 	{
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i);
 			if (element < 0.0) element = -element;
@@ -205,7 +205,7 @@ namespace MbD {
 		//"Test if elements are increasing."
 		//"Ok if spoilers are less than tol."
 		auto next = this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			auto previous = next;
 			next = this->at(i);
@@ -219,7 +219,7 @@ namespace MbD {
 		//"Test if elements are increasing."
 		//"Ok if spoilers are less than tol."
 		auto next = this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			auto previous = next;
 			next = this->at(i);
@@ -232,7 +232,7 @@ namespace MbD {
 	{
 		s << "FullVec{";
 		s << this->at(0);
-		for (int i = 1; i < (int)this->size(); i++)
+		for (size_t i = 1; i < this->size(); i++)
 		{
 			s << ", " << this->at(i);
 		}

--- a/OndselSolver/FunctionWithManyArgs.cpp
+++ b/OndselSolver/FunctionWithManyArgs.cpp
@@ -33,7 +33,7 @@ FunctionWithManyArgs::FunctionWithManyArgs(Symsptr term, Symsptr term1, Symsptr 
 
 FunctionWithManyArgs::FunctionWithManyArgs(std::shared_ptr<std::vector<Symsptr>> _terms) {
 	terms = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < (int)_terms->size(); i++)
+	for (size_t i = 0; i < _terms->size(); i++)
 		terms->push_back(_terms->at(i));
 }
 

--- a/OndselSolver/GeneralSpline.cpp
+++ b/OndselSolver/GeneralSpline.cpp
@@ -37,12 +37,12 @@ void MbD::GeneralSpline::arguments(Symsptr args)
 	auto array = args->getTerms();
 	auto& arg = array->at(0);
 	int order = (int)array->at(1)->getValue();
-	int n = ((int)array->size() - 2) / 2;
+	size_t n = (array->size() - 2) / 2;
 	auto xarray = std::make_shared<std::vector<double>>(n);
 	auto yarray = std::make_shared<std::vector<double>>(n);
-	for (int i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 	{
-		int ii = 2 * ((int)i + 1);
+		size_t ii = 2 * (i + 1);
 		xarray->at(i) = array->at(ii)->getValue();
 		yarray->at(i) = array->at(ii + 1)->getValue();
 	}
@@ -63,41 +63,41 @@ void MbD::GeneralSpline::computeDerivatives()
 {
 	//"See derivation in MbDTheory 9spline.fodt."
 	if (degree == 0) throw std::runtime_error("ToDo: Use ZeroDegreeSpline");
-	auto n = (int)xs->size();
+	auto n = xs->size();
 	auto p = degree;
 	auto np = n * p;
 	auto matrix = std::make_shared<SparseMatrix<double>>(np, np);
 	auto bvector = std::make_shared<FullColumn<double>>(np, 0.0);
 	auto hs = std::make_shared<FullColumn<double>>(n - 1);
 	double hmax = 0.0;
-	for (int i = 0; i < n - 1; i++)
+	for (size_t i = 0; i < n - 1; i++)
 	{
-		double h = xs->at((int)i + 1) - xs->at(i);
+		double h = xs->at(i + 1) - xs->at(i);
 		hmax = std::max(hmax, std::abs(h));
 		hs->atiput(i, h);
 	}
-	for (int i = 0; i < n - 1; i++)
+	for (size_t i = 0; i < n - 1; i++)
 	{
 		auto offset = i * p;
 		double hbar = hs->at(i) / hmax;
-		for (int j = 1; j < p; j++)
+		for (size_t j = 1; j < p; j++)
 		{
 			matrix->atijput(offset + j, offset + j - 1, 1.0);
 			matrix->atijput(offset + j, offset + j - 1 + p, -1.0);
 		}
 		double dum = 1.0;
-		for (int j = 0; j < p; j++)
+		for (size_t j = 0; j < p; j++)
 		{
 			dum = dum * hbar / (j + 1);
-			for (int k = j; k < p; k++)
+			for (size_t k = j; k < p; k++)
 			{
 				matrix->atijput(offset + k - j, offset + k, dum);
 			}
 		}
-		bvector->atiput(offset, ys->at((int)i + 1) - ys->at(i));
+		bvector->atiput(offset, ys->at(i + 1) - ys->at(i));
 	}
 	if (isCyclic()) {
-		for (int j = 1; j < p + 1; j++)
+		for (size_t j = 1; j < p + 1; j++)
 		{
 			matrix->atijput(np - j, np - j, 1.0);
 			matrix->atijput(np - j, p - j, -1.0);
@@ -105,8 +105,8 @@ void MbD::GeneralSpline::computeDerivatives()
 	}
 	else {
 		//"Zero out higher derivatives at node n and node 1 to get the p end equations."
-		auto count = 0;
-		auto npass = 0;
+		size_t count = 0;
+		size_t npass = 0;
 		while (count < p) {
 			matrix->atijput(np - count, np - npass, 1.0);
 			count++;
@@ -121,15 +121,15 @@ void MbD::GeneralSpline::computeDerivatives()
 	auto derivsVector = solver->solvewithsaveOriginal(matrix, bvector, false);
 	derivs = std::make_shared<FullMatrix<double>>(n, p);
 	auto hmaxpowers = std::make_shared<FullColumn<double>>(p);
-	for (int j = 0; j < p; j++)
+	for (size_t j = 0; j < p; j++)
 	{
 		hmaxpowers->atiput(j, std::pow(hmax, j + 1));
 	}
-	for (int i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 	{
 		auto& derivsi = derivs->at(i);
 		derivsi->equalArrayAt(derivsVector, (i - 1) * p + 1);
-		for (int j = 0; j < p; j++)
+		for (size_t j = 0; j < p; j++)
 		{
 			derivsi->atiput(j, derivsi->at(j) / hmaxpowers->at(j));
 		}
@@ -245,14 +245,14 @@ std::ostream& MbD::GeneralSpline::printOn(std::ostream& s) const
 	s << degree << ", " << std::endl;
 	s << "xs{";
 	s << xs->at(0);
-	for (int i = 1; i < (int)xs->size(); i++)
+	for (size_t i = 1; i < xs->size(); i++)
 	{
 		s << ", " << xs->at(i);
 	}
 	s << "}, " << std::endl;
 	s << "ys{";
 	s << ys->at(0);
-	for (int i = 1; i < (int)ys->size(); i++)
+	for (size_t i = 1; i < ys->size(); i++)
 	{
 		s << ", " << ys->at(i);
 	}

--- a/OndselSolver/Joint.cpp
+++ b/OndselSolver/Joint.cpp
@@ -170,7 +170,7 @@ void Joint::fillPosICJacob(SpMatDsptr mat)
 
 void Joint::removeRedundantConstraints(std::shared_ptr<std::vector<int>> redundantEqnNos)
 {
-	for (int i = 0; i < (int)constraints->size(); i++)
+	for (size_t i = 0; i < constraints->size(); i++)
 	{
 		auto& constraint = constraints->at(i);
 		if (std::find(redundantEqnNos->begin(), redundantEqnNos->end(), constraint->iG) != redundantEqnNos->end()) {
@@ -183,7 +183,7 @@ void Joint::removeRedundantConstraints(std::shared_ptr<std::vector<int>> redunda
 
 void Joint::reactivateRedundantConstraints()
 {
-	for (int i = 0; i < (int)constraints->size(); i++)
+	for (size_t i = 0; i < constraints->size(); i++)
 	{
 		auto& con = constraints->at(i);
 		if (con->isRedundant()) {

--- a/OndselSolver/MBDynSystem.cpp
+++ b/OndselSolver/MBDynSystem.cpp
@@ -154,7 +154,7 @@ void MbD::MBDynSystem::outputFiles()
     //auto& asmtMotions = asmtAsm->motions;
 	std::ofstream os(movFile);
 	os << std::setprecision(static_cast<std::streamsize>(std::numeric_limits<double>::digits10) + 1);
-	for (int i = 1; i < (int)asmtTimes->size(); i++)
+	for (size_t i = 1; i < asmtTimes->size(); i++)
 	{
 		for (auto& node : *nodes) {
 			node->outputLine(i, os);
@@ -248,7 +248,7 @@ void MbD::MBDynSystem::readElementsBlock(std::vector<std::string>& lines)
 
 void MbD::MBDynSystem::eraseComments(std::vector<std::string>& lines)
 {
-	for (int i = 0; i < (int)lines.size(); i++)
+	for (size_t i = 0; i < lines.size(); i++)
 	{
 		auto& line = lines[i];
 		auto it = line.find('#');
@@ -256,7 +256,7 @@ void MbD::MBDynSystem::eraseComments(std::vector<std::string>& lines)
 			lines[i] = line.substr(0, it);
 		}
 	}
-	for (int i = (int)lines.size() - 1; i >= 0; i--) {
+	for (size_t i = lines.size() - 1; i >= 0; i--) {
 		auto& line = lines[i];
 		auto it = std::find_if(line.begin(), line.end(), [](unsigned char ch) { return !std::isspace(ch); });
 		if (it == line.end()) lines.erase(lines.begin() + i);

--- a/OndselSolver/MarkerFrame.cpp
+++ b/OndselSolver/MarkerFrame.cpp
@@ -42,7 +42,7 @@ void MarkerFrame::initializeLocally()
 {
 	pprOmOpEpE = EulerParameters<double>::ppApEpEtimesColumn(rpmp);
 	ppAOmpEpE = EulerParameters<double>::ppApEpEtimesMatrix(aApm);
-	for (int i = 0; i < (int)endFrames->size(); i++)
+	for (size_t i = 0; i < endFrames->size(); i++)
 	{
 		auto eFrmqc = std::dynamic_pointer_cast<EndFrameqc>(endFrames->at(i));
 		if (eFrmqc) {

--- a/OndselSolver/MatrixDecomposition.cpp
+++ b/OndselSolver/MatrixDecomposition.cpp
@@ -19,7 +19,7 @@ FColDsptr MbD::MatrixDecomposition::forAndBackSubsaveOriginal(FColDsptr, bool)
 void MatrixDecomposition::applyRowOrderOnRightHandSideB()
 {
 	FColDsptr answer = std::make_shared<FullColumn<double>>(m);
-	for (int i = 0; i < m; i++)
+	for (size_t i = 0; i < m; i++)
 	{
 		answer->at(i) = rightHandSideB->at(rowOrder->at(i));
 	}

--- a/OndselSolver/Numeric.h
+++ b/OndselSolver/Numeric.h
@@ -27,7 +27,7 @@ namespace MbD {
     {
         T previous, next;
         next = vec->at(0);
-        for (int i = 1; i < (int)vec->size(); i++)
+        for (std::size_t i = 1; i < vec->size(); i++)
         {
             previous = next;
             next = vec->at(i);

--- a/OndselSolver/PartFrame.cpp
+++ b/OndselSolver/PartFrame.cpp
@@ -150,7 +150,7 @@ void PartFrame::removeRedundantConstraints(std::shared_ptr<std::vector<int>> red
 		redunCon->constraint = aGeu;
 		aGeu = redunCon;
 	}
-	for (int i = 0; i < (int)aGabs->size(); i++)
+	for (size_t i = 0; i < aGabs->size(); i++)
 	{
 		auto& constraint = aGabs->at(i);
 		if (std::find(redundantEqnNos->begin(), redundantEqnNos->end(), constraint->iG) != redundantEqnNos->end()) {
@@ -164,7 +164,7 @@ void PartFrame::removeRedundantConstraints(std::shared_ptr<std::vector<int>> red
 void PartFrame::reactivateRedundantConstraints()
 {
 	if (aGeu->isRedundant()) aGeu = std::dynamic_pointer_cast<RedundantConstraint>(aGeu)->constraint;
-	for (int i = 0; i < (int)aGabs->size(); i++)
+	for (size_t i = 0; i < aGabs->size(); i++)
 	{
 		auto& con = aGabs->at(i);
 		if (con->isRedundant()) {

--- a/OndselSolver/PiecewiseFunction.cpp
+++ b/OndselSolver/PiecewiseFunction.cpp
@@ -70,7 +70,7 @@ Symsptr MbD::PiecewiseFunction::integrateWRT(Symsptr var)
 		std::back_inserter(*integrals),
 		[var](auto& func) { return func->integrateWRT(var); }
 	);
-	for (int i = 0; i < (int)transitions->size(); i++)
+	for (size_t i = 0; i < transitions->size(); i++)
 	{
 		auto x = transitions->at(i)->getValue();
 		auto fi = integrals->at(i)->getValue(x);
@@ -85,7 +85,7 @@ Symsptr MbD::PiecewiseFunction::integrateWRT(Symsptr var)
 double MbD::PiecewiseFunction::getValue()
 {
 	auto xval = xx->getValue();
-	for (int i = 0; i < (int)transitions->size(); i++)
+	for (size_t i = 0; i < transitions->size(); i++)
 	{
 		if (xval < transitions->at(i)->getValue()) {
 			return functions->at(i)->getValue();
@@ -107,14 +107,14 @@ std::ostream& MbD::PiecewiseFunction::printOn(std::ostream& s) const
 	s << "PiecewiseFunction(" << *xx << ", " << std::endl;
 	s << "functions{" << std::endl;
 	s << *functions->at(0) << std::endl;
-	for (int i = 1; i < (int)functions->size(); i++)
+	for (size_t i = 1; i < functions->size(); i++)
 	{
 		s << *functions->at(i) << std::endl;
 	}
 	s << "}, " << std::endl;
 	s << "transitions{" << std::endl;
 	s << *transitions->at(0) << std::endl;
-	for (int i = 1; i < (int)transitions->size(); i++)
+	for (size_t i = 1; i < transitions->size(); i++)
 	{
 		s << *transitions->at(i) << std::endl;
 	}

--- a/OndselSolver/Polynomial.cpp
+++ b/OndselSolver/Polynomial.cpp
@@ -32,7 +32,7 @@ MbD::Polynomial::Polynomial(Symsptr var, std::shared_ptr<std::vector<Symsptr>> c
 Symsptr MbD::Polynomial::expandUntil(Symsptr, std::shared_ptr<std::unordered_set<Symsptr>> set)
 {
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < (int)coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto coeff = coeffs->at(i);
 		auto newCoeff = coeff->expandUntil(coeff, set);
@@ -44,7 +44,7 @@ Symsptr MbD::Polynomial::expandUntil(Symsptr, std::shared_ptr<std::unordered_set
 Symsptr MbD::Polynomial::simplifyUntil(Symsptr, std::shared_ptr<std::unordered_set<Symsptr>> set)
 {
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < (int)coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto coeff = coeffs->at(i);
 		auto newCoeff = coeff->simplifyUntil(coeff, set);
@@ -58,7 +58,7 @@ Symsptr MbD::Polynomial::differentiateWRTx()
 	//Differentiate powers
 	if (coeffs->size() == 1) return sptrConstant(0.0);
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 1; i < (int)coeffs->size(); i++)
+	for (size_t i = 1; i < coeffs->size(); i++)
 	{
 		auto newCoeff = i * coeffs->at(i)->getValue();
 		newCoeffs->push_back(sptrConstant(newCoeff));
@@ -80,7 +80,7 @@ Symsptr MbD::Polynomial::integrateWRT(Symsptr var)
 	assert(xx == var);
 	auto newCoeffs = std::make_shared<std::vector<Symsptr>>();
 	newCoeffs->push_back(sptrConstant(0.0));
-	for (int i = 0; i < (int)coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		auto newCoeff = coeffs->at(i)->getValue() / (i + 1);
 		newCoeffs->push_back(sptrConstant(newCoeff));
@@ -93,7 +93,7 @@ double MbD::Polynomial::getValue()
 	auto xvalue = xx->getValue();
 	auto xpower = 1.0;
 	auto answer = 0.0;
-	for (int i = 0; i < (int)coeffs->size(); i++)
+	for (size_t i = 0; i < coeffs->size(); i++)
 	{
 		answer += coeffs->at(i)->getValue() * xpower;
 		xpower *= xvalue;
@@ -113,7 +113,7 @@ std::ostream& MbD::Polynomial::printOn(std::ostream& s) const
 	s << *xx << ", ";
 	s << "coeffs{";
 	s << *coeffs->at(0);
-	for (int i = 1; i < (int)coeffs->size(); i++)
+	for (size_t i = 1; i < coeffs->size(); i++)
 	{
 		s << ", " << *coeffs->at(i);
 	}

--- a/OndselSolver/PosICNewtonRaphson.cpp
+++ b/OndselSolver/PosICNewtonRaphson.cpp
@@ -32,7 +32,7 @@ void PosICNewtonRaphson::run()
 			postRun();
 			break;
 		}
-		catch (SingularMatrixError ex) {
+		catch (const SingularMatrixError& ex) {
 			auto redundantEqnNos = ex.getRedundantEqnNos();
 			system->partsJointsMotionsDo([&](std::shared_ptr<Item> item) { item->removeRedundantConstraints(redundantEqnNos); });
 			system->partsJointsMotionsDo([&](std::shared_ptr<Item> item) { item->constraintsReport(); });

--- a/OndselSolver/Product.cpp
+++ b/OndselSolver/Product.cpp
@@ -29,7 +29,7 @@ Symsptr MbD::Product::differentiateWRT(Symsptr var)
 		}
 	);
 	auto derivativeTerms = std::make_shared<std::vector<Symsptr>>();
-	for (int i = 0; i < (int)terms->size(); i++)
+	for (size_t i = 0; i < terms->size(); i++)
 	{
 		auto& derivative = derivatives->at(i);
 		auto newTermFunctions = std::make_shared<std::vector<Symsptr>>(*terms);
@@ -162,7 +162,7 @@ bool Product::isProduct()
 double Product::getValue()
 {
 	double answer = 1.0;
-	for (int i = 0; i < (int)terms->size(); i++) answer *= terms->at(i)->getValue();
+	for (size_t i = 0; i < terms->size(); i++) answer *= terms->at(i)->getValue();
 	return answer;
 }
 

--- a/OndselSolver/QuasiIntegrator.cpp
+++ b/OndselSolver/QuasiIntegrator.cpp
@@ -41,7 +41,7 @@ void QuasiIntegrator::run()
 			try {
 				IntegratorInterface::run();
 			}
-			catch (SingularMatrixError ex) {
+			catch (const SingularMatrixError& ex) {
 				std::stringstream ss;
 				ss << "MbD: Solver has encountered a singular matrix." << std::endl;
 				ss << "MbD: Check to see if a massless or a very low mass part is under constrained." << std::endl;
@@ -53,7 +53,7 @@ void QuasiIntegrator::run()
 				throw SimulationStoppingError("");
 			}
 		}
-		catch (TooSmallStepSizeError ex) {
+		catch (const TooSmallStepSizeError& ex) {
 			std::stringstream ss;
 			ss << "MbD: Step size is prevented from going below the user specified minimum." << std::endl;
 			ss << "MbD: Check to see if the system is in a locked position." << std::endl;
@@ -64,7 +64,7 @@ void QuasiIntegrator::run()
 			throw SimulationStoppingError("");
 		}
 	}
-	catch (TooManyTriesError ex) {
+	catch (const TooManyTriesError& ex) {
 		std::stringstream ss;
 		ss << "MbD: Check to see if the error tolerance is too demanding." << std::endl;
 		auto str = ss.str();

--- a/OndselSolver/RowTypeMatrix.h
+++ b/OndselSolver/RowTypeMatrix.h
@@ -34,7 +34,7 @@ namespace MbD {
 	template<typename T>
 	inline void RowTypeMatrix<T>::copyFrom(std::shared_ptr<RowTypeMatrix<T>> x)
 	{
-		for (int i = 0; i < (int)x->size(); i++) {
+		for (size_t i = 0; i < x->size(); i++) {
 			this->at(i)->copyFrom(x->at(i));
 		}
 	}
@@ -42,7 +42,7 @@ namespace MbD {
 	//inline double RowTypeMatrix<T>::maxMagnitude()
 	//{
 	//	double max = 0.0;
-	//	for (int i = 0; i < this->size(); i++)
+	//	for (size_t i = 0; i < this->size(); i++)
 	//	{
 	//		double element = this->at(i)->maxMagnitude();
 	//		if (max < element) max = element;

--- a/OndselSolver/SparseMatrix.h
+++ b/OndselSolver/SparseMatrix.h
@@ -98,7 +98,7 @@ namespace MbD {
 	inline double SparseMatrix<T>::sumOfSquares()
 	{
 		double sum = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			sum += this->at(i)->sumOfSquares();
 		}
@@ -107,7 +107,7 @@ namespace MbD {
 	template<>
 	inline void SparseMatrix<double>::zeroSelf()
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->zeroSelf();
 		}
 	}
@@ -119,7 +119,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::atijplusFullColumn(int i, int j, FColsptr<T> fullCol)
 	{
-		for (int ii = 0; ii < (int)fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->atijplusNumber(i + ii, j, fullCol->at(ii));
 		}
@@ -127,7 +127,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::atijminusFullColumn(int i, int j, FColDsptr fullCol)
 	{
-		for (int ii = 0; ii < fullCol->size(); ii++)
+		for (size_t ii = 0; ii < fullCol->size(); ii++)
 		{
 			this->atijminusNumber(i + ii, j, fullCol->at(ii));
 		}
@@ -191,7 +191,7 @@ namespace MbD {
 	inline double SparseMatrix<T>::maxMagnitude()
 	{
 		double max = 0.0;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			double element = this->at(i)->maxMagnitude();
 			if (max < element) max = element;
@@ -202,7 +202,7 @@ namespace MbD {
 	inline std::ostream& SparseMatrix<T>::printOn(std::ostream& s) const
 	{
 		s << "SpMat[" << std::endl;
-		for (int i = 0; i < (int)this->size(); i++)
+		for (size_t i = 0; i < this->size(); i++)
 		{
 			s << *(this->at(i)) << std::endl;
 		}
@@ -229,7 +229,7 @@ namespace MbD {
 		//"Just evaluate quickly."
 
 		auto answer = clonesptr();
-		for (int i = 0; i < answer->size(); i++)
+		for (size_t i = 0; i < answer->size(); i++)
 		{
 			answer->atiput(i, answer->at(i)->plusSparseRow(spMat->at(i)));
 		}
@@ -243,7 +243,7 @@ namespace MbD {
 	template<typename T>
 	inline void SparseMatrix<T>::magnifySelf(T factor)
 	{
-		for (int i = 0; i < (int)this->size(); i++) {
+		for (size_t i = 0; i < this->size(); i++) {
 			this->at(i)->magnifySelf(factor);
 		}
 	}

--- a/OndselSolver/StableBackwardDifference.cpp
+++ b/OndselSolver/StableBackwardDifference.cpp
@@ -95,7 +95,7 @@ FColDsptr MbD::StableBackwardDifference::derivativepresentpast(int deriv, FColDs
 			return std::static_pointer_cast<FullColumn<double>>(answer);
 		}
 		else {
-            auto ySize = (int)y->size();
+            auto ySize = y->size();
 			return std::make_shared<FullColumn<double>>(ySize, 0.0);
 		}
 	}

--- a/OndselSolver/Sum.cpp
+++ b/OndselSolver/Sum.cpp
@@ -127,7 +127,7 @@ bool Sum::isSum()
 double Sum::getValue()
 {
 	double answer = 0.0;
-	for (int i = 0; i < (int)terms->size(); i++) answer += terms->at(i)->getValue();
+	for (size_t i = 0; i < terms->size(); i++) answer += terms->at(i)->getValue();
 	return answer;
 }
 

--- a/OndselSolver/System.cpp
+++ b/OndselSolver/System.cpp
@@ -186,7 +186,7 @@ double System::maximumMass()
 double System::maximumMomentOfInertia()
 {
 	double max = 0.0;
-	for (int i = 0; i < (int)parts->size(); i++)
+	for (size_t i = 0; i < parts->size(); i++)
 	{
 		auto& part = parts->at(i);
 		for (int j = 0; j < 3; j++)

--- a/OndselSolver/SystemSolver.cpp
+++ b/OndselSolver/SystemSolver.cpp
@@ -159,7 +159,7 @@ void SystemSolver::runBasicKinematic()
 		basicIntegrator->setSystem(this);
 		basicIntegrator->run();
 	}
-	catch (NotKinematicError ex) {
+	catch (const NotKinematicError& ex) {
 		this->runQuasiKinematic();
 	}
 }
@@ -171,7 +171,7 @@ void SystemSolver::runQuasiKinematic()
 		basicIntegrator->setSystem(this);
 		basicIntegrator->run();
 	}
-	catch (DiscontinuityError ex) {
+	catch (const DiscontinuityError& ex) {
 		this->discontinuityBlock();
 	}
 }

--- a/OndselSolver/VectorNewtonRaphson.cpp
+++ b/OndselSolver/VectorNewtonRaphson.cpp
@@ -53,7 +53,7 @@ void VectorNewtonRaphson::solveEquations()
 	try {
 		this->basicSolveEquations();
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 		this->handleSingularMatrix();
 	}
 }

--- a/OndselSolver/VelSolver.cpp
+++ b/OndselSolver/VelSolver.cpp
@@ -58,7 +58,7 @@ void VelSolver::solveEquations()
 	try {
 		this->basicSolveEquations();
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 		this->handleSingularMatrix();
 	}
 }


### PR DESCRIPTION
This MR fixes the majority of the signed-vs-unsigned comparison warnings, see #29.

For the remaining warnings, some of the function parameter types and member variables would need changing, so these changes are left out for now.