### PR TITLE
fix includes for gcc-14

### DIFF
--- a/OndselSolver/FunctionX.cpp
+++ b/OndselSolver/FunctionX.cpp
@@ -6,6 +6,8 @@
  *   See LICENSE file for details about copyright.                         *
  ***************************************************************************/
 
+#include <algorithm>
+
 #include "FunctionX.h"
 #include "Constant.h"
 #include "Sum.h"

--- a/OndselSolver/SymbolicParser.cpp
+++ b/OndselSolver/SymbolicParser.cpp
@@ -9,6 +9,7 @@
 #include "corecrt_math_defines.h"
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 
 #include "SymbolicParser.h"
 #include "BasicUserFunction.h"


### PR DESCRIPTION
gcc-14 is more disciplined about not including <algorithm> transitively.