### PR TITLE
Mark unused variables to silence compiler warnings.

### DIFF
--- a/OndselSolver/ASMTAllowRotation.cpp
+++ b/OndselSolver/ASMTAllowRotation.cpp
@@ -57,6 +57,7 @@ std::shared_ptr<ItemIJ> MbD::ASMTAllowRotation::mbdClassNew()
 
 void MbD::ASMTAllowRotation::setMotionJoint(std::string motionJoint)
 {
+    (void) motionJoint;
 }
 
 void MbD::ASMTAllowRotation::storeOnLevel(std::ofstream& os, size_t level)

--- a/OndselSolver/ASMTAssembly.cpp
+++ b/OndselSolver/ASMTAssembly.cpp
@@ -1473,6 +1473,7 @@ void MbD::ASMTAssembly::compareResults(AnalysisType type)
 
 void MbD::ASMTAssembly::outputResults(AnalysisType type)
 {
+    (void) type;
 	//ASMTSpatialContainer::outputResults(type);
 	//for (auto& part : *parts) part->outputResults(type);
 	//for (auto& joint : *joints) joint->outputResults(type);

--- a/OndselSolver/ASMTItemIJ.cpp
+++ b/OndselSolver/ASMTItemIJ.cpp
@@ -161,6 +161,8 @@ void MbD::ASMTItemIJ::parseASMT(std::vector<std::string>& lines)
 
 void MbD::ASMTItemIJ::createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits)
 {
+    (void) mbdSys;
+    (void) mbdUnits;
 	//self dataSeries : OrderedCollection new.
 	//self discontinuities : OrderedCollection new.
 	auto mbdJt = this->mbdClassNew();

--- a/OndselSolver/LimitIJ.cpp
+++ b/OndselSolver/LimitIJ.cpp
@@ -9,11 +9,13 @@ MbD::LimitIJ::LimitIJ()
 
 void MbD::LimitIJ::fillAccICIterError(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillAccICIterJacob(SpMatDsptr mat)
 {
+    (void) mat;
 	assert(false);
 }
 
@@ -49,16 +51,19 @@ void MbD::LimitIJ::fillConstraints(std::shared_ptr<std::vector<std::shared_ptr<C
 
 void MbD::LimitIJ::fillDispConstraints(std::shared_ptr<std::vector<std::shared_ptr<Constraint>>> dispConstraints)
 {
+    (void) dispConstraints;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillEssenConstraints(std::shared_ptr<std::vector<std::shared_ptr<Constraint>>> essenConstraints)
 {
+    (void) essenConstraints;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillPerpenConstraints(std::shared_ptr<std::vector<std::shared_ptr<Constraint>>> perpenConstraints)
 {
+    (void) perpenConstraints;
 	assert(false);
 }
 
@@ -78,16 +83,19 @@ void MbD::LimitIJ::fillPosICJacob(SpMatDsptr mat)
 
 void MbD::LimitIJ::fillPosKineError(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillPosKineJacob(SpMatDsptr mat)
 {
+    (void) mat;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillqsuddotlam(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
@@ -100,31 +108,37 @@ void MbD::LimitIJ::fillqsulam(FColDsptr col)
 
 void MbD::LimitIJ::fillqsudot(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillqsudotWeights(DiagMatDsptr diagMat)
 {
+    (void) diagMat;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillVelICError(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
 void MbD::LimitIJ::fillVelICJacob(SpMatDsptr mat)
 {
+    (void) mat;
 	assert(false);
 }
 
 void MbD::LimitIJ::setqsuddotlam(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 
 void MbD::LimitIJ::setqsudotlam(FColDsptr col)
 {
+    (void) col;
 	assert(false);
 }
 

--- a/OndselSolver/PosICDragLimitNewtonRaphson.cpp
+++ b/OndselSolver/PosICDragLimitNewtonRaphson.cpp
@@ -31,6 +31,7 @@ void MbD::PosICDragLimitNewtonRaphson::initializeGlobally()
 
 void MbD::PosICDragLimitNewtonRaphson::setdragParts(std::shared_ptr<std::vector<std::shared_ptr<Part>>> dragParts)
 {
+    (void) dragParts;
 	assert(false);
 }
 


### PR DESCRIPTION
Fixes https://github.com/Ondsel-Development/OndselSolver/issues/63 and allows FreeCAD to be compiled with "-Werror=unused-variable".