### PR TITLE
Correct compilation warnings for 'int' casts with correct types

### DIFF
--- a/OndselSolver/GEFullMat.cpp
+++ b/OndselSolver/GEFullMat.cpp
@@ -21,7 +21,7 @@ void GEFullMat::backSubstituteIntoDU()
 {
 	answerX = std::make_shared<FullColumn<double>>(n);
 	answerX->at(n - 1) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(n - 1);
-	for (int i = (int)n - 2; i >= 0; i--)	//Use int because of decrement
+	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto rowi = matrixA->at(i);
 		double sum = answerX->at(n) * rowi->at(n);

--- a/OndselSolver/GESpMatFullPv.cpp
+++ b/OndselSolver/GESpMatFullPv.cpp
@@ -118,14 +118,14 @@ void GESpMatFullPv::backSubstituteIntoDU()
 	auto jn = colOrder->at(n);
 	answerX->at(jn) = rightHandSideB->at(m) / matrixA->at(m)->at(jn);
 	//auto rhsZeroElement = this->rhsZeroElement();
-	for (int i = (int)n - 2; i >= 0; i--)	//Use int because of decrement
+	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto& rowi = matrixA->at(i);
 		sum = 0.0; // rhsZeroElement copy.
 		for (auto const& keyValue : *rowi) {
 			auto jj = keyValue.first;
 			auto j = positionsOfOriginalCols->at(jj);
-			if ((int) j > i) {
+			if ((ssize_t) j > i) {
 				duij = keyValue.second;
 				sum += answerX->at(jj) * duij;
 			}

--- a/OndselSolver/GESpMatParPv.cpp
+++ b/OndselSolver/GESpMatParPv.cpp
@@ -54,13 +54,13 @@ void GESpMatParPv::backSubstituteIntoDU()
 	answerX = std::make_shared<FullColumn<double>>(m);
 	answerX->at(n - 1) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(n - 1);
 	//auto rhsZeroElement = this->rhsZeroElement();
-	for (int i = (int)n - 2; i >= 0; i--)	//Use int because of decrement
+	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto rowi = matrixA->at(i);
 		sum = 0.0; // rhsZeroElement copy.
 		for (auto const& keyValue : *rowi) {
 			auto j = keyValue.first;
-			if ((int)j > i) {
+			if ((ssize_t)j > i) {
 				duij = keyValue.second;
 				sum += answerX->at(j) * duij;
 			}

--- a/OndselSolver/GESpMatParPvMarko.cpp
+++ b/OndselSolver/GESpMatParPvMarko.cpp
@@ -20,17 +20,17 @@ void GESpMatParPvMarko::doPivoting(size_t p)
 	//"Do scaling. Do partial pivoting."
 	//"criterion := mag / (2.0d raisedTo: rowiCount)."
 	//| lookForFirstNonZeroInPivotCol i rowi aip criterionMax rowPivoti criterion max |
-	int i;	//Use int because of decrement
+	ssize_t i;	//Use ssize_t because of decrement
 	size_t rowPivoti;
 	double aip, mag, max, criterion, criterionMax;
 	SpRowDsptr spRowi;
 	rowPositionsOfNonZerosInPivotColumn->clear();
 	auto lookForFirstNonZeroInPivotCol = true;
-	i = (int)m - 1;
+	i = (ssize_t)m - 1;
 	while (lookForFirstNonZeroInPivotCol) {
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
-			if (i <= (int)p) throwSingularMatrixError(""); //Use int because i can be negative
+			if (i <= (ssize_t)p) throwSingularMatrixError(""); //Use ssize_t because i can be negative
 		}
 		else {
 			markowitzPivotColCount = 0;
@@ -44,7 +44,7 @@ void GESpMatParPvMarko::doPivoting(size_t p)
 		}
 		i--;
 	}
-	while (i >= (int)p) { //Use int because i can be negative
+	while (i >= (ssize_t)p) { //Use ssize_t because i can be negative
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
 			aip = std::numeric_limits<double>::min();

--- a/OndselSolver/GESpMatParPvMarkoFast.cpp
+++ b/OndselSolver/GESpMatParPvMarkoFast.cpp
@@ -51,17 +51,17 @@ void GESpMatParPvMarkoFast::doPivoting(size_t p)
 	//"Pivot size are nieither checked nor stored."
 
 	//| lookForFirstNonZeroInPivotCol i rowi aip criterionMax rowPivoti criterion max |
-	int i;	//Use int because of decrement
+	ssize_t i;	//Use ssize_t because of decrement
 	size_t rowPivoti;
 	double aip, max, criterion, criterionMax;
 	SpRowDsptr spRowi;
 	rowPositionsOfNonZerosInPivotColumn->clear();
 	auto lookForFirstNonZeroInPivotCol = true;
-	i = (int)m - 1;
+	i = (ssize_t)m - 1;
 	while (lookForFirstNonZeroInPivotCol) {
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
-			if (i <= (int)p) throwSingularMatrixError("");	//Use int because i can be negative
+			if (i <= (ssize_t)p) throwSingularMatrixError("");	//Use ssize_t because i can be negative
 		}
 		else {
 			markowitzPivotColCount = 0;
@@ -74,7 +74,7 @@ void GESpMatParPvMarkoFast::doPivoting(size_t p)
 		}
 		i--;
 	}
-	while (i >= (int)p) {	//Use int because i can be negative
+	while (i >= (ssize_t)p) {	//Use ssize_t because i can be negative
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
 			aip = std::numeric_limits<double>::min();

--- a/OndselSolver/GESpMatParPvPrecise.cpp
+++ b/OndselSolver/GESpMatParPvPrecise.cpp
@@ -21,17 +21,17 @@ void GESpMatParPvPrecise::doPivoting(size_t p)
 	//"Check for singular pivot."
 	//"Do scaling. Do partial pivoting."
 	//| max rowPivot aip mag lookForFirstNonZeroInPivotCol i |
-	int i;	//Use int because of decrement
+	ssize_t i;	//Use ssize_t because of decrement
 	size_t rowPivoti;
 	double aip, mag, max;
 	SpRowDsptr spRowi;
 	rowPositionsOfNonZerosInPivotColumn->clear();
 	auto lookForFirstNonZeroInPivotCol = true;
-	i = (int)m - 1;
+	i = (ssize_t)m - 1;
 	while (lookForFirstNonZeroInPivotCol) {
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
-			if (i <= (int)p) throwSingularMatrixError("doPivoting");	//Use int because i can be negative
+			if (i <= (ssize_t)p) throwSingularMatrixError("doPivoting");	//Use ssize_t because i can be negative
 		}
 		else {
 			markowitzPivotColCount = 0;
@@ -44,7 +44,7 @@ void GESpMatParPvPrecise::doPivoting(size_t p)
 		}
 		i--;
 	}
-	while (i >= (int)p) { //Use int because i can be negative
+	while (i >= (ssize_t)p) { //Use ssize_t because i can be negative
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
 			aip = std::numeric_limits<double>::min();

--- a/OndselSolver/GeneralSpline.cpp
+++ b/OndselSolver/GeneralSpline.cpp
@@ -149,7 +149,7 @@ double MbD::GeneralSpline::derivativeAt(size_t n, double xxx)
 	calcIndexAndDeltaFor(xxx);
 	auto& derivsi = derivs->at(index);
 	double sum = 0.0;
-	for (int j = (int)degree; j >= (int) n + 1; j--)	//Use int because of decrement
+	for (ssize_t j = (ssize_t)degree; j >= (ssize_t) n + 1; j--)	//Use ssize_t because of decrement
 	{
 		sum = (sum + derivsi->at((size_t)j - 1)) * delta / (j - n);
 	}
@@ -231,7 +231,7 @@ double MbD::GeneralSpline::y(double xxx)
 	calcIndexAndDeltaFor(xxx);
 	auto& derivsi = derivs->at(index);
 	double sum = 0.0;
-	for (int j = (int)degree; j >= 1; j--)	//Use int because of decrement
+	for (ssize_t j = (ssize_t)degree; j >= 1; j--)	//Use ssize_t because of decrement
 	{
 		sum = (sum + derivsi->at((size_t)j - 1)) * delta / j;
 	}

--- a/OndselSolver/LDUFullMat.cpp
+++ b/OndselSolver/LDUFullMat.cpp
@@ -156,11 +156,11 @@ void LDUFullMat::backSubstituteIntoDU()
 		//| rowi sum |
 	answerX = std::make_shared<FullColumn<double>>(n);
 	answerX->at(n - 1) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(n - 1);
-	for (int i = (int)n - 2; i >= 0; i--)	//Use int because of decrement
+	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto& rowi = matrixA->at(i);
-		double sum = answerX->at((size_t)n - 1) * rowi->at((size_t)n - 1);
-		for (int j = i + 1; j < (int)n - 1; j++)
+		double sum = answerX->at(n - 1) * rowi->at(n - 1);
+		for (size_t j = i + 1; j < n - 1; j++)
 		{
 			sum += answerX->at(j) * rowi->at(j);
 		}

--- a/OndselSolver/LDUSpMat.cpp
+++ b/OndselSolver/LDUSpMat.cpp
@@ -69,7 +69,7 @@ void LDUSpMat::backSubstituteIntoDU()
 	}
 	answerX = std::make_shared<FullColumn<double>>(m);
 	answerX->at(n - 1) = rightHandSideB->at(m - 1);
-	for (int i = (int)n - 2; i >= 0; i--)	//Use int because of decrement
+	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto& rowi = matrixU->at(i);
 		sum = 0.0;

--- a/OndselSolver/LDUSpMatParPvMarko.cpp
+++ b/OndselSolver/LDUSpMatParPvMarko.cpp
@@ -18,17 +18,17 @@ void LDUSpMatParPvMarko::doPivoting(size_t p)
 	//"Do scaling. Do partial pivoting."
 	//"criterion := mag / (2.0d raisedTo: rowiCount)."
 	//| lookForFirstNonZeroInPivotCol i rowi aip criterionMax rowPivoti criterion max |
-	int i;	//Use int because of decrement
+	ssize_t i;	//Use ssize_t because of decrement
 	size_t rowPivoti;
 	double aip, mag, max, criterion, criterionMax;
 	SpRowDsptr spRowi;
 	rowPositionsOfNonZerosInPivotColumn->clear();
 	auto lookForFirstNonZeroInPivotCol = true;
-	i = (int)m - 1;
+	i = (ssize_t)m - 1;
 	while (lookForFirstNonZeroInPivotCol) {
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
-			if (i <= (int)p) throwSingularMatrixError(""); //Use int because i can be negative
+			if (i <= (ssize_t)p) throwSingularMatrixError(""); //Use ssize_t because i can be negative
 		}
 		else {
 			markowitzPivotColCount = 0;
@@ -42,7 +42,7 @@ void LDUSpMatParPvMarko::doPivoting(size_t p)
 		}
 		i--;
 	}
-	while (i >= (int)p) { //Use int because i can be negative
+	while (i >= (ssize_t)p) { //Use ssize_t because i can be negative
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
 			aip = std::numeric_limits<double>::min();

--- a/OndselSolver/LDUSpMatParPvPrecise.cpp
+++ b/OndselSolver/LDUSpMatParPvPrecise.cpp
@@ -18,17 +18,17 @@ void LDUSpMatParPvPrecise::doPivoting(size_t p)
 	//"Check for singular pivot."
 	//"Do scaling. Do partial pivoting."
 	//| max rowPivot aip mag lookForFirstNonZeroInPivotCol i |
-	int i;	//Use int because of decrement
+	ssize_t i;	//Use ssize_t because of decrement
 	size_t rowPivoti;
 	double aip, mag, max;
 	SpRowDsptr spRowi;
 	rowPositionsOfNonZerosInPivotColumn->clear();
 	auto lookForFirstNonZeroInPivotCol = true;
-	i = (int)m - 1;
+	i = (ssize_t)m - 1;
 	while (lookForFirstNonZeroInPivotCol) {
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
-			if (i <= (int)p) throwSingularMatrixError(""); //Use int because i can be negative
+			if (i <= (ssize_t)p) throwSingularMatrixError(""); //Use ssize_t because i can be negative
 		}
 		else {
 			markowitzPivotColCount = 0;
@@ -41,7 +41,7 @@ void LDUSpMatParPvPrecise::doPivoting(size_t p)
 		}
 		i--;
 	}
-	while (i >= (int)p) { //Use int because i can be negative
+	while (i >= (ssize_t)p) { //Use ssize_t because i can be negative
 		spRowi = matrixA->at(i);
 		if (spRowi->find(p) == spRowi->end()) {
 			aip = std::numeric_limits<double>::min();

--- a/OndselSolver/Numeric.h
+++ b/OndselSolver/Numeric.h
@@ -11,6 +11,12 @@
 #include <cstddef>
 #include <limits>
 
+// For Windows platforms only, cstddef includes size_t but not ssize_t
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include "MbDMath.h"
 
 namespace MbD {

--- a/OndselSolver/StableBackwardDifference.cpp
+++ b/OndselSolver/StableBackwardDifference.cpp
@@ -59,7 +59,7 @@ void StableBackwardDifference::formTaylorRowwithTimeNodederivative(size_t i, siz
 	//| rowi hi hipower aij |
 	auto& rowi = taylorMatrix->at(i);
 	if (k > 0) {
-		for (int j = 0; j < (int)k - 2; j++)	//Use int because of subtraction
+		for (ssize_t j = 0; j < (ssize_t)k - 2; j++)
 		{
 			rowi->at(j) = 0.0;
 		}

--- a/OndselSolver/SymbolicParser.cpp
+++ b/OndselSolver/SymbolicParser.cpp
@@ -192,17 +192,16 @@ bool MbD::SymbolicParser::peekForTypeNoPush(const std::string& c)
 
 std::string MbD::SymbolicParser::scanToken()
 {
-	prevEnd = (int)source->tellg();	//Use int because of decrement
-	prevEnd--;
+        prevEnd = source->tellg() - std::streamoff(1);
 	while (std::isspace(hereChar) || isNextLineTag(hereChar)) {
 		hereChar = source->get();
 	}
 	if (hereChar == EOF) {
-		mark = prevEnd + 1;
+		mark = prevEnd + std::streamoff(1);;
 		tokenType = "end";
 		return token = "";
 	}
-	mark = (int)source->tellg();
+	mark = source->tellg();
 	if (std::isalpha(hereChar)) {
 		xLetter();
 	}

--- a/OndselSolver/SymbolicParser.h
+++ b/OndselSolver/SymbolicParser.h
@@ -58,7 +58,7 @@ namespace MbD {
 		std::shared_ptr<std::map<std::string, Symsptr>> variables;
 		std::shared_ptr<std::vector<ASMTItemIJ>> geoIJs;
 		std::shared_ptr<Units> units;
-		int mark = -1, prevEnd = -1;
+		std::streampos mark = 0, prevEnd = 0;
 		char hereChar = '\0';
 		std::string token, tokenType;
 		double tokenNum = -1.0e100;


### PR DESCRIPTION
Fix a potential error on some specific architectures (aka devices with `sizeof(int)` different of `sizeof(ssize_t)`) where a `size_t` or `ssize_t` are not actually a real `int`. When dealing (subtracting or adding values) with `size_t` with negative value, `int `you should not be use but rather its dedicated opposite version, aka the signed one: `ssize_t`

Also, when dealing with `tellg`, actually it returns a `streampos` (see [C++ Reference | std::streampos](https://cplusplus.com/reference/ios/streampos/) ) which should not be incremented or decremented with any integer. Instead, a dedicated method should be called by using `std::streamoff` for that in the class (see [C++ Reference | std::streamoff](https://cplusplus.com/reference/ios/streamoff/) ) 