### PR TITLE
Correct compilation warnings with exceptions

### DIFF
--- a/OndselSolver/ASMTAssembly.cpp
+++ b/OndselSolver/ASMTAssembly.cpp
@@ -1434,7 +1434,7 @@ void MbD::ASMTAssembly::runKINEMATIC()
     try {
         mbdSystem->runKINEMATIC(mbdSystem);
     }
-    catch (SimulationStoppingError ex) {
+    catch (const SimulationStoppingError& ex) {
     }
 }
 

--- a/OndselSolver/DifferenceOperator.cpp
+++ b/OndselSolver/DifferenceOperator.cpp
@@ -36,7 +36,7 @@ void DifferenceOperator::calcOperatorMatrix()
 	try {
 		operatorMatrix = CREATE<LDUFullMatParPv>::With()->inversesaveOriginal(taylorMatrix, false);
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 	}
 }
 

--- a/OndselSolver/PosICNewtonRaphson.cpp
+++ b/OndselSolver/PosICNewtonRaphson.cpp
@@ -32,7 +32,7 @@ void PosICNewtonRaphson::run()
 			postRun();
 			break;
 		}
-		catch (SingularMatrixError ex) {
+		catch (const SingularMatrixError& ex) {
 			auto redundantEqnNos = ex.getRedundantEqnNos();
 			system->partsJointsMotionsLimitsDo([&](std::shared_ptr<Item> item) { item->removeRedundantConstraints(redundantEqnNos); });
 			system->partsJointsMotionsLimitsDo([&](std::shared_ptr<Item> item) { item->constraintsReport(); });

--- a/OndselSolver/QuasiIntegrator.cpp
+++ b/OndselSolver/QuasiIntegrator.cpp
@@ -41,7 +41,7 @@ void QuasiIntegrator::run()
 			try {
 				IntegratorInterface::run();
 			}
-			catch (SingularMatrixError ex) {
+			catch (const SingularMatrixError& ex) {
 				std::stringstream ss;
 				ss << "MbD: Solver has encountered a singular matrix." << std::endl;
 				ss << "MbD: Check to see if a massless or a very low mass part is under constrained." << std::endl;
@@ -53,7 +53,7 @@ void QuasiIntegrator::run()
 				throw SimulationStoppingError("singular matrix");
 			}
 		}
-		catch (TooSmallStepSizeError ex) {
+		catch (const TooSmallStepSizeError& ex) {
 			std::stringstream ss;
 			ss << "MbD: Step size is prevented from going below the user specified minimum." << std::endl;
 			ss << "MbD: Check to see if the system is in a locked position." << std::endl;
@@ -64,7 +64,7 @@ void QuasiIntegrator::run()
 			throw SimulationStoppingError("stepSize < stepSizeMin");
 		}
 	}
-	catch (TooManyTriesError ex) {
+	catch (const TooManyTriesError& ex) {
 		std::stringstream ss;
 		ss << "MbD: Check to see if the error tolerance is too demanding." << std::endl;
 		auto str = ss.str();

--- a/OndselSolver/SystemSolver.cpp
+++ b/OndselSolver/SystemSolver.cpp
@@ -161,7 +161,7 @@ void SystemSolver::runBasicKinematic()
 		basicIntegrator->setSystem(this);
 		basicIntegrator->run();
 	}
-	catch (NotKinematicError ex) {
+	catch (const NotKinematicError& ex) {
 		this->runQuasiKinematic();
 	}
 }
@@ -186,7 +186,7 @@ void SystemSolver::runQuasiKinematic()
 		basicIntegrator->setSystem(this);
 		basicIntegrator->run();
 	}
-	catch (DiscontinuityError ex) {
+	catch (const DiscontinuityError& ex) {
 		this->discontinuityBlock();
 	}
 }

--- a/OndselSolver/VectorNewtonRaphson.cpp
+++ b/OndselSolver/VectorNewtonRaphson.cpp
@@ -53,7 +53,7 @@ void VectorNewtonRaphson::solveEquations()
 	try {
 		this->basicSolveEquations();
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 		this->handleSingularMatrix();
 	}
 }

--- a/OndselSolver/VelSolver.cpp
+++ b/OndselSolver/VelSolver.cpp
@@ -58,7 +58,7 @@ void VelSolver::solveEquations()
 	try {
 		this->basicSolveEquations();
 	}
-	catch (SingularMatrixError ex) {
+	catch (const SingularMatrixError& ex) {
 		this->handleSingularMatrix();
 	}
 }


### PR DESCRIPTION
This is to fix the warnings compilation in FreeCAD due to the usage of the `-Wcatch=value` compilation flag which expect exception to be `const` and passed by value.