### PR TITLE
include cstdint for SIZE_MAX

### DIFF
--- a/OndselSolver/AbsConstraint.h
+++ b/OndselSolver/AbsConstraint.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "Constraint.h"
 namespace MbD {
 	class AbsConstraint : public Constraint

--- a/OndselSolver/AngleZConstraintIqcJc.h
+++ b/OndselSolver/AngleZConstraintIqcJc.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "AngleZConstraintIJ.h"
 
 namespace MbD {

--- a/OndselSolver/AngleZConstraintIqcJqc.h
+++ b/OndselSolver/AngleZConstraintIqcJqc.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "AngleZConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/AnyPosICNewtonRaphson.h
+++ b/OndselSolver/AnyPosICNewtonRaphson.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "PosNewtonRaphson.h"
 #include "DiagonalMatrix.h"
 

--- a/OndselSolver/AtPointConstraintIqcJc.h
+++ b/OndselSolver/AtPointConstraintIqcJc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "AtPointConstraintIJ.h"
 
 namespace MbD {

--- a/OndselSolver/AtPointConstraintIqcJqc.h
+++ b/OndselSolver/AtPointConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "AtPointConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/ConstVelConstraintIqcJc.h
+++ b/OndselSolver/ConstVelConstraintIqcJc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "ConstVelConstraintIJ.h"
 
 namespace MbD {

--- a/OndselSolver/ConstVelConstraintIqcJqc.h
+++ b/OndselSolver/ConstVelConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "ConstVelConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/Constraint.cpp
+++ b/OndselSolver/Constraint.cpp
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <chrono>
+#include <cstdint>
 
 #include "Constraint.h"
 #include "FullColumn.h"

--- a/OndselSolver/Constraint.h
+++ b/OndselSolver/Constraint.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "enum.h"

--- a/OndselSolver/DirectionCosineConstraintIqcJc.h
+++ b/OndselSolver/DirectionCosineConstraintIqcJc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "DirectionCosineConstraintIJ.h"
 
 namespace MbD {

--- a/OndselSolver/DirectionCosineConstraintIqcJqc.h
+++ b/OndselSolver/DirectionCosineConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "DirectionCosineConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/DispCompIecJecO.h
+++ b/OndselSolver/DispCompIecJecO.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "KinematicIeJe.h"
 
 namespace MbD {

--- a/OndselSolver/EulerConstraint.h
+++ b/OndselSolver/EulerConstraint.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/OndselSolver/FullMatrix.h
+++ b/OndselSolver/FullMatrix.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <memory>
 
 #include "RowTypeMatrix.h"

--- a/OndselSolver/GESpMat.h
+++ b/OndselSolver/GESpMat.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "MatrixGaussElimination.h"
 #include "SparseMatrix.h"
 

--- a/OndselSolver/GESpMatFullPvPosIC.cpp
+++ b/OndselSolver/GESpMatFullPvPosIC.cpp
@@ -8,6 +8,7 @@
  
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 
 #include "GESpMatFullPvPosIC.h"
 #include "SingularMatrixError.h"

--- a/OndselSolver/GeneralSpline.h
+++ b/OndselSolver/GeneralSpline.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "AnyGeneralSpline.h"
 
 namespace MbD {

--- a/OndselSolver/NewtonRaphson.cpp
+++ b/OndselSolver/NewtonRaphson.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <limits>
 #include <cassert>
+#include <cstdint>
 
 #include "NewtonRaphson.h"
 #include "SystemSolver.h"

--- a/OndselSolver/NewtonRaphson.h
+++ b/OndselSolver/NewtonRaphson.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/OndselSolver/Part.h
+++ b/OndselSolver/Part.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "Item.h"

--- a/OndselSolver/PartFrame.cpp
+++ b/OndselSolver/PartFrame.cpp
@@ -7,6 +7,7 @@
  ***************************************************************************/
  
 #include<algorithm>
+#include <cstdint>
 
 #include "PartFrame.h"
 #include "Part.h"

--- a/OndselSolver/PartFrame.h
+++ b/OndselSolver/PartFrame.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <functional>

--- a/OndselSolver/RackPinConstraintIqcJqc.h
+++ b/OndselSolver/RackPinConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "RackPinConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/ScrewConstraintIqcJqc.h
+++ b/OndselSolver/ScrewConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "ScrewConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/TranslationConstraintIqcJqc.h
+++ b/OndselSolver/TranslationConstraintIqcJqc.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "TranslationConstraintIqcJc.h"
 
 namespace MbD {

--- a/OndselSolver/VectorNewtonRaphson.h
+++ b/OndselSolver/VectorNewtonRaphson.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "NewtonRaphson.h"

--- a/OndselSolver/VelICSolver.h
+++ b/OndselSolver/VelICSolver.h
@@ -8,6 +8,8 @@
  
 #pragma once
 
+#include <cstdint>
+
 #include "VelSolver.h"
 
 namespace MbD {

--- a/OndselSolver/VelSolver.h
+++ b/OndselSolver/VelSolver.h
@@ -8,6 +8,7 @@
  
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "Solver.h"


### PR DESCRIPTION
GCC 15 is removing cstdint from the C++ Standard Library.

https://gcc.gnu.org/gcc-15/porting_to.html

```
error: ‘SIZE_MAX’ was not declared in this scope
note: ‘SIZE_MAX’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```
